### PR TITLE
feat: add enterprise Teams support and enrich conversation/message schemas

### DIFF
--- a/plugins/teams/src/teams-api.ts
+++ b/plugins/teams/src/teams-api.ts
@@ -1,18 +1,51 @@
 import { ToolError, findLocalStorageEntry, parseRetryAfterMs, waitUntil } from '@opentabs-dev/plugin-sdk';
 
 // ---------------------------------------------------------------------------
-// MSAL token discovery
+// Environment detection
 // ---------------------------------------------------------------------------
 
-const MSAL_CLIENT_ID = '4b3e8f46-56d3-427f-b1e2-d239b2ea6bca';
+type TeamsEnvironment = 'consumer' | 'enterprise';
 
-/**
- * Scope suffix for the Skype API MSAL token. MSAL stores access tokens in
- * localStorage under long composite keys containing the tenant ID, home
- * account ID, client ID, and target scope separated by dashes. We search
- * for keys that end with a known scope suffix to locate the token.
- */
-const SKYPE_API_SCOPE = 'service::api.fl.spaces.skype.com::mbi_ssl--';
+/** Detect whether we are running on consumer or enterprise Teams. */
+const detectEnvironment = (): TeamsEnvironment => {
+  try {
+    if (typeof window !== 'undefined' && window.location.hostname === 'teams.live.com') {
+      return 'consumer';
+    }
+  } catch {
+    // Fall through to enterprise default
+  }
+  return 'enterprise';
+};
+
+interface EnvConfig {
+  msalClientId: string;
+  msalScopeSuffix: string;
+  authzUrl: string;
+  chatServiceBase: string | null; // null = discover from localStorage
+}
+
+const CONSUMER_CONFIG: EnvConfig = {
+  msalClientId: '4b3e8f46-56d3-427f-b1e2-d239b2ea6bca',
+  msalScopeSuffix: 'service::api.fl.spaces.skype.com::mbi_ssl--',
+  authzUrl: 'https://teams.live.com/api/auth/v1.0/authz/consumer',
+  chatServiceBase: 'https://teams.live.com/api/chatsvc/consumer',
+};
+
+const ENTERPRISE_CONFIG: EnvConfig = {
+  msalClientId: '5e3ce6c0-2b1f-4285-8d4b-75ee78787346',
+  msalScopeSuffix: 'https://api.spaces.skype.com/.default--',
+  authzUrl: 'https://teams.microsoft.com/api/authsvc/v1.0/authz',
+  chatServiceBase: null, // Discovered at runtime from regionGtms
+};
+
+const getConfig = (): EnvConfig => {
+  return detectEnvironment() === 'consumer' ? CONSUMER_CONFIG : ENTERPRISE_CONFIG;
+};
+
+// ---------------------------------------------------------------------------
+// MSAL token discovery
+// ---------------------------------------------------------------------------
 
 interface MsalAccessToken {
   secret: string;
@@ -24,10 +57,8 @@ interface MsalAccessToken {
  * Find an MSAL access token in localStorage by matching the client ID and
  * scope suffix in the key.
  */
-const findMsalToken = (scopeSuffix: string): MsalAccessToken | null => {
-  const entry = findLocalStorageEntry(
-    (key) => key.includes(MSAL_CLIENT_ID) && key.endsWith(scopeSuffix),
-  );
+const findMsalToken = (clientId: string, scopeSuffix: string): MsalAccessToken | null => {
+  const entry = findLocalStorageEntry(key => key.includes(clientId) && key.endsWith(scopeSuffix));
   if (!entry) return null;
   try {
     const parsed = JSON.parse(entry.value) as Record<string, unknown>;
@@ -40,6 +71,57 @@ const findMsalToken = (scopeSuffix: string): MsalAccessToken | null => {
   return null;
 };
 
+/** Find the MSAL token for the current environment. */
+const findEnvMsalToken = (): MsalAccessToken | null => {
+  const config = getConfig();
+  return findMsalToken(config.msalClientId, config.msalScopeSuffix);
+};
+
+// ---------------------------------------------------------------------------
+// Enterprise chat service URL discovery
+// ---------------------------------------------------------------------------
+
+/** Cached enterprise chat service URL. */
+let cachedEnterpriseChatServiceBase: string | null = null;
+
+/**
+ * Discover the enterprise chat service URL from the regionGtms data stored
+ * in localStorage by the Teams SPA. Falls back to the AFD proxy URL.
+ */
+const discoverEnterpriseChatServiceBase = (): string => {
+  if (cachedEnterpriseChatServiceBase) return cachedEnterpriseChatServiceBase;
+
+  const entry = findLocalStorageEntry(key => key.includes('Discover.SKYPE-TOKEN'));
+  if (entry) {
+    try {
+      const data = JSON.parse(entry.value) as {
+        item?: { regionGtms?: { chatService?: string; chatServiceAfd?: string } };
+      };
+      const chatService = data.item?.regionGtms?.chatService;
+      if (chatService) {
+        cachedEnterpriseChatServiceBase = chatService;
+        return chatService;
+      }
+      const chatServiceAfd = data.item?.regionGtms?.chatServiceAfd;
+      if (chatServiceAfd) {
+        cachedEnterpriseChatServiceBase = chatServiceAfd;
+        return chatServiceAfd;
+      }
+    } catch {
+      // Fall through to default
+    }
+  }
+
+  // Default fallback — AMER region AFD proxy
+  return 'https://teams.microsoft.com/api/chatsvc/amer';
+};
+
+/** Get the chat service base URL for the current environment. */
+const getChatServiceBase = (): string => {
+  const config = getConfig();
+  return config.chatServiceBase ?? discoverEnterpriseChatServiceBase();
+};
+
 // ---------------------------------------------------------------------------
 // Skype JWT exchange
 // ---------------------------------------------------------------------------
@@ -48,22 +130,27 @@ const findMsalToken = (scopeSuffix: string): MsalAccessToken | null => {
 let cachedSkypeJwt: { token: string; expiresAt: number } | null = null;
 
 /**
- * Exchange the MSAL Skype API token for a Skype JWT via the consumer authz
- * endpoint. The JWT is cached until 60 seconds before expiration.
+ * Exchange the MSAL Skype API token for a Skype JWT via the authz endpoint.
+ * Works for both consumer and enterprise environments.
+ * The JWT is cached until 60 seconds before expiration.
  */
 const getSkypeJwt = async (): Promise<string> => {
   if (cachedSkypeJwt && Date.now() < cachedSkypeJwt.expiresAt - 60_000) {
     return cachedSkypeJwt.token;
   }
 
-  const msalToken = findMsalToken(SKYPE_API_SCOPE);
+  const config = getConfig();
+  const msalToken = findEnvMsalToken();
   if (!msalToken) {
-    throw ToolError.auth('Not authenticated — no MSAL Skype API token found. Please log in to Microsoft Teams.');
+    const env = detectEnvironment();
+    throw ToolError.auth(
+      `Not authenticated — no MSAL Skype API token found for ${env} Teams. Please log in to Microsoft Teams.`,
+    );
   }
 
   let response: Response;
   try {
-    response = await fetch('https://teams.live.com/api/auth/v1.0/authz/consumer', {
+    response = await fetch(config.authzUrl, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${msalToken.secret}`,
@@ -88,13 +175,21 @@ const getSkypeJwt = async (): Promise<string> => {
     throw ToolError.internal(`Skype JWT exchange error (${String(response.status)}): ${body.substring(0, 256)}`);
   }
 
-  const data = (await response.json()) as { skypeToken?: { skypetoken?: string; expiresIn?: number } };
-  const jwt = data.skypeToken?.skypetoken;
+  const data = (await response.json()) as {
+    // Consumer format: { skypeToken: { skypetoken, expiresIn } }
+    skypeToken?: { skypetoken?: string; expiresIn?: number };
+    // Enterprise format: { tokens: { skypeToken, expiresIn } }
+    tokens?: { skypeToken?: string; expiresIn?: number };
+  };
+
+  // Enterprise returns the JWT in tokens.skypeToken (string);
+  // consumer returns it in skypeToken.skypetoken (nested object).
+  const jwt = data.tokens?.skypeToken ?? data.skypeToken?.skypetoken;
   if (!jwt) {
     throw ToolError.internal('Skype JWT exchange returned empty token');
   }
 
-  const expiresIn = data.skypeToken?.expiresIn ?? 3600;
+  const expiresIn = data.tokens?.expiresIn ?? data.skypeToken?.expiresIn ?? 3600;
   cachedSkypeJwt = { token: jwt, expiresAt: Date.now() + expiresIn * 1000 };
   return jwt;
 };
@@ -109,16 +204,58 @@ interface SkypeIdentity {
 }
 
 /**
+ * Decode a JWT payload without verification (we only need to read claims).
+ */
+const decodeJwtPayload = (jwt: string): Record<string, unknown> => {
+  const parts = jwt.split('.');
+  if (parts.length < 2) return {};
+  try {
+    const base64 = parts[1]?.replace(/-/g, '+').replace(/_/g, '/') ?? '';
+    return JSON.parse(atob(base64)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Find the sign-in email from the MSAL ID token stored in localStorage.
+ * Enterprise authz responses do not include the email, so we read it from
+ * the cached ID token instead.
+ */
+const findSignInName = (): string => {
+  const config = getConfig();
+  const entry = findLocalStorageEntry(
+    key => key.includes(config.msalClientId) && key.toLowerCase().includes('-idtoken-'),
+  );
+  if (!entry) return '';
+  try {
+    const parsed = JSON.parse(entry.value) as { secret?: string };
+    if (parsed.secret) {
+      const claims = decodeJwtPayload(parsed.secret);
+      return String(claims.preferred_username ?? claims.upn ?? claims.email ?? '');
+    }
+  } catch {
+    // Malformed entry
+  }
+  return '';
+};
+
+/**
  * Get the current user's Skype identity (MRI and sign-in email) by performing
  * a Skype JWT exchange and reading the identity fields from the response.
+ * On enterprise, identity is extracted from the JWT payload and MSAL ID token.
  */
 export const getSkypeIdentity = async (): Promise<SkypeIdentity> => {
-  const msalToken = findMsalToken(SKYPE_API_SCOPE);
+  const config = getConfig();
+  const msalToken = findEnvMsalToken();
   if (!msalToken) {
-    throw ToolError.auth('Not authenticated — no MSAL Skype API token found. Please log in to Microsoft Teams.');
+    const env = detectEnvironment();
+    throw ToolError.auth(
+      `Not authenticated — no MSAL Skype API token found for ${env} Teams. Please log in to Microsoft Teams.`,
+    );
   }
 
-  const response = await fetch('https://teams.live.com/api/auth/v1.0/authz/consumer', {
+  const response = await fetch(config.authzUrl, {
     method: 'POST',
     headers: { Authorization: `Bearer ${msalToken.secret}`, 'Content-Type': 'application/json' },
     credentials: 'include',
@@ -129,10 +266,27 @@ export const getSkypeIdentity = async (): Promise<SkypeIdentity> => {
     throw ToolError.auth(`Failed to get identity: HTTP ${String(response.status)}`);
   }
 
-  const data = (await response.json()) as { skypeToken?: { skypeid?: string; signinname?: string } };
+  const data = (await response.json()) as {
+    // Consumer format
+    skypeToken?: { skypeid?: string; signinname?: string; skypetoken?: string };
+    // Enterprise format
+    tokens?: { skypeToken?: string };
+  };
+
+  // Consumer returns identity directly in the response
+  if (data.skypeToken?.skypeid) {
+    return {
+      skypeid: data.skypeToken.skypeid,
+      signinname: data.skypeToken.signinname ?? '',
+    };
+  }
+
+  // Enterprise: decode the JWT to get skypeid, and read email from MSAL ID token
+  const jwt = data.tokens?.skypeToken ?? data.skypeToken?.skypetoken ?? '';
+  const claims = jwt ? decodeJwtPayload(jwt) : {};
   return {
-    skypeid: data.skypeToken?.skypeid ?? '',
-    signinname: data.skypeToken?.signinname ?? '',
+    skypeid: String(claims.skypeid ?? ''),
+    signinname: findSignInName(),
   };
 };
 
@@ -140,7 +294,7 @@ export const getSkypeIdentity = async (): Promise<SkypeIdentity> => {
 // Authentication detection
 // ---------------------------------------------------------------------------
 
-export const isTeamsAuthenticated = (): boolean => findMsalToken(SKYPE_API_SCOPE) !== null;
+export const isTeamsAuthenticated = (): boolean => findEnvMsalToken() !== null;
 
 /**
  * Wait for MSAL to populate the auth tokens after SPA hydration.
@@ -156,11 +310,10 @@ export const waitForTeamsAuth = (): Promise<boolean> =>
 // Chat Service API
 // ---------------------------------------------------------------------------
 
-const CHAT_SERVICE_BASE = 'https://teams.live.com/api/chatsvc/consumer';
-
 /**
  * Make an authenticated request to the Teams Chat Service (Skype-based API).
  * Uses the Skype JWT obtained via MSAL token exchange.
+ * Automatically routes to the correct endpoint for consumer or enterprise.
  */
 export const chatApi = async <T>(
   endpoint: string,
@@ -171,9 +324,10 @@ export const chatApi = async <T>(
   } = {},
 ): Promise<T> => {
   const skypeJwt = await getSkypeJwt();
+  const chatServiceBase = getChatServiceBase();
   const { method = 'GET', body, query } = options;
 
-  let url = `${CHAT_SERVICE_BASE}${endpoint}`;
+  let url = `${chatServiceBase}${endpoint}`;
   if (query) {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(query)) {
@@ -218,13 +372,14 @@ export const createThread = async (
   properties?: Record<string, unknown>,
 ): Promise<string> => {
   const skypeJwt = await getSkypeJwt();
+  const chatServiceBase = getChatServiceBase();
 
   const body: Record<string, unknown> = { members };
   if (properties) body.properties = properties;
 
   let response: Response;
   try {
-    response = await fetch(`${CHAT_SERVICE_BASE}/v1/threads`, {
+    response = await fetch(`${chatServiceBase}/v1/threads`, {
       method: 'POST',
       headers: {
         Authentication: `skypetoken=${skypeJwt}`,
@@ -268,8 +423,9 @@ export const threadApi = async <T>(
   } = {},
 ): Promise<T> => {
   const skypeJwt = await getSkypeJwt();
+  const chatServiceBase = getChatServiceBase();
   const { method = 'GET', body } = options;
-  const url = `${CHAT_SERVICE_BASE}/v1/threads/${encodeURIComponent(threadId)}${subpath}`;
+  const url = `${chatServiceBase}/v1/threads/${encodeURIComponent(threadId)}${subpath}`;
 
   let response: Response;
   try {

--- a/plugins/teams/src/tools/schemas.ts
+++ b/plugins/teams/src/tools/schemas.ts
@@ -6,11 +6,15 @@ import { z } from 'zod';
 
 export const conversationSchema = z.object({
   id: z.string().describe('Conversation/thread ID'),
+  topic: z.string().describe('Chat name/topic (empty for unnamed 1:1 chats)'),
   type: z.string().describe('Conversation type (e.g., "Conversation")'),
-  thread_type: z.string().describe('Thread type (e.g., "chat", "topic")'),
+  thread_type: z.string().describe('Thread type (e.g., "chat", "meeting", "space")'),
+  member_count: z.string().describe('Number of members in the conversation'),
+  created_at: z.string().describe('When the conversation was created (ISO 8601)'),
   last_message_content: z.string().describe('Content of the last message'),
   last_message_type: z.string().describe('Message type of the last message'),
   last_message_time: z.string().describe('Timestamp of the last message'),
+  last_message_from: z.string().describe('Display name of the last message sender'),
   version: z.number().describe('Conversation version'),
 });
 
@@ -26,12 +30,35 @@ interface RawConversation {
 
 export const mapConversation = (c: RawConversation): Conversation => ({
   id: c.id ?? '',
+  topic: String(c.threadProperties?.topic ?? ''),
   type: c.type ?? '',
   thread_type: String(c.threadProperties?.threadType ?? ''),
+  member_count: String(c.threadProperties?.memberCount ?? ''),
+  created_at: String(c.threadProperties?.createdat ?? ''),
   last_message_content: String(c.lastMessage?.content ?? ''),
   last_message_type: String(c.lastMessage?.messagetype ?? ''),
   last_message_time: String(c.lastMessage?.composetime ?? ''),
+  last_message_from: String(c.lastMessage?.imdisplayname ?? ''),
   version: typeof c.version === 'number' ? c.version : 0,
+});
+
+// ---------------------------------------------------------------------------
+// Mention schema
+// ---------------------------------------------------------------------------
+
+const mentionSchema = z.object({
+  mri: z.string().describe('Mentioned user MRI (e.g., "8:orgid:...")'),
+  display_name: z.string().describe('Display name of the mentioned user'),
+});
+
+// ---------------------------------------------------------------------------
+// File attachment schema
+// ---------------------------------------------------------------------------
+
+const fileSchema = z.object({
+  title: z.string().describe('File name'),
+  type: z.string().describe('File type (e.g., "image/png", "application/pdf")'),
+  url: z.string().describe('File download URL'),
 });
 
 // ---------------------------------------------------------------------------
@@ -43,13 +70,27 @@ export const messageSchema = z.object({
   client_message_id: z.string().describe('Client-assigned message ID'),
   content: z.string().describe('Message content (may contain HTML)'),
   message_type: z.string().describe('Message type (e.g., "RichText/Html", "Text")'),
-  from: z.string().describe('Sender MRI (e.g., "8:live:username")'),
+  from: z.string().describe('Sender MRI (e.g., "8:orgid:username")'),
   display_name: z.string().describe('Sender display name'),
   compose_time: z.string().describe('When the message was composed (ISO 8601)'),
   conversation_id: z.string().describe('ID of the conversation this message belongs to'),
+  mentions: z.array(mentionSchema).describe('Users mentioned in this message'),
+  files: z.array(fileSchema).describe('Files attached to this message'),
+  reactions: z.array(z.string()).describe('Reaction emoji keys on this message (e.g., ["like", "heart"])'),
 });
 
 export type Message = z.infer<typeof messageSchema>;
+
+interface RawMention {
+  mri?: string;
+  displayName?: string;
+}
+
+interface RawFile {
+  title?: string;
+  type?: string;
+  objectUrl?: string;
+}
 
 interface RawMessage {
   id?: string;
@@ -60,12 +101,52 @@ interface RawMessage {
   imdisplayname?: string;
   composetime?: string;
   conversationid?: string;
+  properties?: {
+    mentions?: string;
+    files?: string;
+    emotions?: Array<{ key?: string }>;
+  };
+  annotationsSummary?: {
+    emotions?: Array<{ key?: string }>;
+  };
 }
 
 /** Extract the MRI (e.g., "8:live:username") from a full contact URL. */
 const extractMri = (from: string): string => {
   const match = /\/contacts\/(.+)$/.exec(from);
   return match?.[1] ?? from;
+};
+
+/** Parse mentions from the serialized JSON string in properties.mentions. */
+const parseMentions = (raw?: string): Array<{ mri: string; display_name: string }> => {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw) as RawMention[];
+    return arr.map(m => ({ mri: m.mri ?? '', display_name: m.displayName ?? '' }));
+  } catch {
+    return [];
+  }
+};
+
+/** Parse files from the serialized JSON string in properties.files. */
+const parseFiles = (raw?: string): Array<{ title: string; type: string; url: string }> => {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw) as RawFile[];
+    return arr.map(f => ({ title: f.title ?? '', type: f.type ?? '', url: f.objectUrl ?? '' }));
+  } catch {
+    return [];
+  }
+};
+
+/** Extract unique reaction keys from emotions/annotationsSummary. */
+const parseReactions = (msg: RawMessage): string[] => {
+  const emotions = msg.properties?.emotions ?? msg.annotationsSummary?.emotions ?? [];
+  const keys = new Set<string>();
+  for (const e of emotions) {
+    if (e.key) keys.add(e.key);
+  }
+  return [...keys];
 };
 
 export const mapMessage = (m: RawMessage): Message => ({
@@ -77,4 +158,7 @@ export const mapMessage = (m: RawMessage): Message => ({
   display_name: m.imdisplayname ?? '',
   compose_time: m.composetime ?? '',
   conversation_id: m.conversationid ?? '',
+  mentions: parseMentions(m.properties?.mentions),
+  files: parseFiles(m.properties?.files),
+  reactions: parseReactions(m),
 });


### PR DESCRIPTION
## Summary

- The Teams plugin only worked with **consumer/personal Teams** (`teams.live.com`). Enterprise/work Teams at `teams.microsoft.com` matched the URL pattern but failed silently because the plugin used hardcoded consumer-only MSAL client IDs, auth endpoints, and chat service URLs.
- Added **runtime environment detection** (consumer vs enterprise) that routes all auth and API calls through the correct endpoints for each environment.
- Enriched conversation and message schemas with fields the API already returns but were not being mapped (chat names, mentions, files, reactions).

## What changed

**Enterprise support (`teams-api.ts`):**

| Aspect | Consumer (existing) | Enterprise (new) |
|--------|-------------------|------------------|
| MSAL Client ID | `4b3e8f46-...` (consumer app) | `5e3ce6c0-...` (standard MS Teams web client) |
| MSAL Scope Suffix | `service::api.fl.spaces.skype.com::mbi_ssl--` | `https://api.spaces.skype.com/.default--` |
| Auth Endpoint | `teams.live.com/api/auth/v1.0/authz/consumer` | `teams.microsoft.com/api/authsvc/v1.0/authz` |
| Chat Service | `teams.live.com/api/chatsvc/consumer` | Discovered from `regionGtms` in localStorage |
| Authz Response | `{ skypeToken: { skypetoken } }` | `{ tokens: { skypeToken } }` |
| Identity | From authz response fields | JWT payload + MSAL ID token |

**Schema enrichments (`schemas.ts`):**

Conversations:
- `topic` — chat name/title from `threadProperties.topic`
- `member_count` — number of participants
- `created_at` — conversation creation timestamp
- `last_message_from` — display name of last message sender

Messages:
- `mentions` — parsed @mention data (MRI + display name)
- `files` — attached file metadata (name, type, URL)
- `reactions` — emoji reaction keys from emotions/annotationsSummary

No changes to any tool files — all routing is in `teams-api.ts` and all schema mapping is in `schemas.ts`.

## How it works

1. `detectEnvironment()` checks `window.location.hostname` — `teams.live.com` = consumer, everything else = enterprise
2. Environment-specific config provides the correct MSAL client ID, scope suffix, and authz URL
3. Enterprise chat service URL is discovered from `regionGtms.chatService` in localStorage (populated by the Teams SPA), with fallback to the AMER AFD proxy
4. Authz response parsing handles both formats
5. Enterprise user identity is extracted by decoding the Skype JWT payload for `skypeid` and reading the MSAL ID token for `preferred_username`

## Test plan

- [x] Tested `list_conversations` against live enterprise Teams at `teams.microsoft.com/v2/` — returns conversations with topic names
- [x] Tested `read_messages` against enterprise Teams — returns messages with display names
- [x] All quality checks pass: `type-check`, `lint`, `format:check`, `knip`
- [ ] Verify consumer Teams (`teams.live.com`) still works (no consumer account available — consumer code paths are unchanged)
- [ ] Test with non-AMER region enterprise tenants (EMEA, APAC) to verify `regionGtms` discovery