### PR TITLE
feat(cli): add --stdio bridge for MCP client auto-start & additional Allowed Directiories via config.json

### DIFF
--- a/e2e/additional-allowed-dirs.e2e.ts
+++ b/e2e/additional-allowed-dirs.e2e.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E tests for additionalAllowedDirectories config — verify that plugins
+ * located outside the default allowed roots (home, tmp) can be discovered
+ * when their parent directory is listed in additionalAllowedDirectories.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { McpClient, McpServer } from './fixtures.js';
+import {
+  cleanupTestConfigDir,
+  createMcpClient,
+  createMinimalPlugin,
+  E2E_TEST_PLUGIN_DIR,
+  expect,
+  readPluginToolNames,
+  startMcpServer,
+  test,
+  writeTestConfig,
+} from './fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const configWithPlugins = (
+  localPlugins: string[],
+  additionalAllowedDirectories: string[],
+  extraTools: Record<string, boolean> = {},
+): {
+  localPlugins: string[];
+  tools: Record<string, boolean>;
+  additionalAllowedDirectories: string[];
+} => {
+  const absPluginPath = path.resolve(E2E_TEST_PLUGIN_DIR);
+  const prefixedToolNames = readPluginToolNames();
+  const tools: Record<string, boolean> = {};
+  for (const t of prefixedToolNames) tools[t] = true;
+  return {
+    localPlugins: [absPluginPath, ...localPlugins],
+    tools: { ...tools, ...extraTools },
+    additionalAllowedDirectories,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('additionalAllowedDirectories', () => {
+  test('plugin in an additional allowed directory is discovered', async () => {
+    let tmpDir: string | undefined;
+    let configDir: string | undefined;
+    let server: McpServer | undefined;
+    let client: McpClient | undefined;
+    try {
+      // Create plugin in a temp directory (which is within os.tmpdir, already allowed)
+      // but the key test is that the config field is threaded through discovery
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opentabs-e2e-allowdirs-'));
+      const pluginDir = createMinimalPlugin(tmpDir, 'allowed-dir-test', [{ name: 'ping', description: 'A ping tool' }]);
+
+      configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opentabs-e2e-allowdirs-cfg-'));
+      const config = configWithPlugins([pluginDir], [tmpDir], { 'allowed-dir-test_ping': true });
+      writeTestConfig(configDir, config);
+
+      server = await startMcpServer(configDir, true);
+      client = createMcpClient(server.port, server.secret);
+      await client.initialize();
+
+      const health = await server.waitForHealth(h => {
+        const plugin = h.pluginDetails?.find(p => p.name === 'allowed-dir-test');
+        return plugin !== undefined;
+      }, 15_000);
+
+      const plugin = health.pluginDetails?.find(p => p.name === 'allowed-dir-test');
+      expect(plugin).toBeDefined();
+      expect(plugin?.toolCount).toBe(1);
+
+      // Verify tool is in tools/list
+      const tools = await client.listTools();
+      expect(tools.some(t => t.name === 'allowed-dir-test_ping')).toBe(true);
+    } finally {
+      await client?.close();
+      await server?.kill();
+      if (configDir) cleanupTestConfigDir(configDir);
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('additionalAllowedDirectories is preserved across config saves', async () => {
+    let configDir: string | undefined;
+    let server: McpServer | undefined;
+    try {
+      configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opentabs-e2e-allowdirs-persist-'));
+      const absPluginPath = path.resolve(E2E_TEST_PLUGIN_DIR);
+      const extraDirs = ['/opt/custom-plugins', '/srv/plugins'];
+
+      writeTestConfig(configDir, {
+        localPlugins: [absPluginPath],
+        additionalAllowedDirectories: extraDirs,
+      });
+
+      server = await startMcpServer(configDir, true);
+      await server.waitForHealth(h => h.status === 'ok');
+
+      // Trigger a reload (which re-reads and re-writes config internally)
+      const reloadRes = await fetch(`http://localhost:${String(server.port)}/reload`, {
+        method: 'POST',
+        headers: server.secret ? { Authorization: `Bearer ${server.secret}` } : {},
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(reloadRes.ok).toBe(true);
+
+      // Read config and verify additionalAllowedDirectories is preserved
+      const configPath = path.join(configDir, 'config.json');
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        additionalAllowedDirectories?: string[];
+      };
+      expect(config.additionalAllowedDirectories).toBeDefined();
+      expect(config.additionalAllowedDirectories).toContain('/opt/custom-plugins');
+      expect(config.additionalAllowedDirectories).toContain('/srv/plugins');
+    } finally {
+      await server?.kill();
+      if (configDir) cleanupTestConfigDir(configDir);
+    }
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -208,6 +208,8 @@ interface OpentabsConfig {
   tools?: Record<string, boolean>;
   /** Per-plugin settings (short plugin name → key/value pairs). */
   settings?: Record<string, Record<string, unknown>>;
+  /** Extra directories allowed for local plugin resolution (beyond ~/). */
+  additionalAllowedDirectories?: string[];
 }
 
 /**

--- a/e2e/stdio-bridge.e2e.ts
+++ b/e2e/stdio-bridge.e2e.ts
@@ -1,0 +1,264 @@
+/**
+ * E2E tests for the stdio bridge (`opentabs start --stdio`).
+ *
+ * Verifies the bridge can proxy MCP JSON-RPC between stdin/stdout and the
+ * HTTP server, including initialize, tools/list, and session cleanup.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createInterface } from 'node:readline';
+import type { McpServer } from './fixtures.js';
+import {
+  cleanupTestConfigDir,
+  E2E_TEST_PLUGIN_DIR,
+  expect,
+  readPluginToolNames,
+  startMcpServer,
+  test,
+  writeTestConfig,
+} from './fixtures.js';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const CLI_ENTRY = path.join(ROOT, 'platform/cli/dist/cli.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface BridgeProcess {
+  proc: ChildProcess;
+  /** Send a JSON-RPC message to the bridge's stdin. */
+  send: (message: Record<string, unknown>) => void;
+  /** Wait for the next JSON-RPC response on stdout (matching the given id). */
+  waitForResponse: (id: number, timeoutMs?: number) => Promise<Record<string, unknown>>;
+  /** Kill the bridge process. */
+  kill: () => Promise<void>;
+}
+
+/**
+ * Spawn the stdio bridge as a child process connected to an existing MCP server.
+ */
+const spawnBridge = (port: number, configDir: string): BridgeProcess => {
+  const proc = spawn('node', [CLI_ENTRY, 'start', '--stdio', '--port', String(port)], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      OPENTABS_CONFIG_DIR: configDir,
+    },
+  });
+
+  const lines: string[] = [];
+  const waiters: Array<{ id: number; resolve: (v: Record<string, unknown>) => void; reject: (e: Error) => void }> = [];
+
+  const stdout = proc.stdout;
+  if (!stdout) throw new Error('Bridge process has no stdout');
+  const rl = createInterface({ input: stdout });
+  rl.on('line', (line: string) => {
+    lines.push(line);
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      const responseId = parsed.id as number | undefined;
+      if (responseId !== undefined) {
+        const idx = waiters.findIndex(w => w.id === responseId);
+        if (idx >= 0) {
+          const waiter = waiters.splice(idx, 1)[0];
+          if (waiter) waiter.resolve(parsed);
+        }
+      }
+    } catch {
+      // Not JSON — ignore (e.g., log output that leaked to stdout)
+    }
+  });
+
+  const send = (message: Record<string, unknown>): void => {
+    proc.stdin?.write(`${JSON.stringify(message)}\n`);
+  };
+
+  const waitForResponse = (id: number, timeoutMs = 15_000): Promise<Record<string, unknown>> =>
+    new Promise((resolve, reject) => {
+      // Check if already received
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line) as Record<string, unknown>;
+          if ((parsed.id as number) === id) {
+            resolve(parsed);
+            return;
+          }
+        } catch {
+          // ignore
+        }
+      }
+
+      const timer = setTimeout(() => {
+        const idx = waiters.findIndex(w => w.id === id);
+        if (idx >= 0) waiters.splice(idx, 1);
+        reject(new Error(`Timed out waiting for response id=${String(id)} after ${String(timeoutMs)}ms`));
+      }, timeoutMs);
+
+      waiters.push({
+        id,
+        resolve: v => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        reject: e => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+    });
+
+  const kill = async (): Promise<void> => {
+    if (proc.exitCode !== null) return;
+    return new Promise<void>(resolve => {
+      proc.once('exit', () => resolve());
+      // Close stdin to trigger graceful shutdown
+      proc.stdin?.end();
+      // Fallback: force kill after 5s
+      const fallback = setTimeout(() => {
+        try {
+          proc.kill();
+        } catch {
+          /* already dead */
+        }
+      }, 5_000);
+      proc.once('exit', () => clearTimeout(fallback));
+    });
+  };
+
+  return { proc, send, waitForResponse, kill };
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('stdio bridge', () => {
+  test('initialize and tools/list via stdio bridge', async () => {
+    let configDir: string | undefined;
+    let server: McpServer | undefined;
+    let bridge: BridgeProcess | undefined;
+    try {
+      // Create isolated config with e2e-test plugin
+      configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opentabs-e2e-stdio-'));
+      const absPluginPath = path.resolve(E2E_TEST_PLUGIN_DIR);
+      const prefixedToolNames = readPluginToolNames();
+      const tools: Record<string, boolean> = {};
+      for (const t of prefixedToolNames) tools[t] = true;
+      writeTestConfig(configDir, { localPlugins: [absPluginPath], tools });
+
+      // Start MCP server
+      server = await startMcpServer(configDir, true);
+      await server.waitForHealth(h => h.status === 'ok');
+
+      // Spawn the stdio bridge
+      bridge = spawnBridge(server.port, configDir);
+
+      // Send initialize request
+      bridge.send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'e2e-test', version: '1.0.0' },
+        },
+      });
+
+      const initResponse = await bridge.waitForResponse(1);
+      expect(initResponse.jsonrpc).toBe('2.0');
+      expect(initResponse.id).toBe(1);
+      expect(initResponse.result).toBeDefined();
+
+      const result = initResponse.result as Record<string, unknown>;
+      expect(result.serverInfo).toBeDefined();
+      expect(result.capabilities).toBeDefined();
+
+      // Send initialized notification (no response expected)
+      bridge.send({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      });
+
+      // Small delay for notification processing
+      await new Promise(r => setTimeout(r, 500));
+
+      // Send tools/list request
+      bridge.send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      });
+
+      const toolsResponse = await bridge.waitForResponse(2);
+      expect(toolsResponse.jsonrpc).toBe('2.0');
+      expect(toolsResponse.id).toBe(2);
+      expect(toolsResponse.result).toBeDefined();
+
+      const toolsResult = toolsResponse.result as { tools: Array<{ name: string }> };
+      expect(toolsResult.tools).toBeInstanceOf(Array);
+      expect(toolsResult.tools.length).toBeGreaterThan(0);
+
+      // Verify e2e-test plugin tools are present
+      const toolNames = toolsResult.tools.map(t => t.name);
+      expect(toolNames.some(n => n.startsWith('e2e-test_'))).toBe(true);
+    } finally {
+      await bridge?.kill();
+      await server?.kill();
+      if (configDir) cleanupTestConfigDir(configDir);
+    }
+  });
+
+  test('bridge proxies error responses for invalid methods', async () => {
+    let configDir: string | undefined;
+    let server: McpServer | undefined;
+    let bridge: BridgeProcess | undefined;
+    try {
+      configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opentabs-e2e-stdio-err-'));
+      const absPluginPath = path.resolve(E2E_TEST_PLUGIN_DIR);
+      writeTestConfig(configDir, { localPlugins: [absPluginPath] });
+
+      server = await startMcpServer(configDir, true);
+      await server.waitForHealth(h => h.status === 'ok');
+
+      bridge = spawnBridge(server.port, configDir);
+
+      // Send initialize first
+      bridge.send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'e2e-test', version: '1.0.0' },
+        },
+      });
+      await bridge.waitForResponse(1);
+
+      // Send a request without initializing first won't work, but after
+      // init, send an unknown method — the server returns an error response
+      bridge.send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'nonexistent/method',
+        params: {},
+      });
+
+      const errorResponse = await bridge.waitForResponse(2);
+      expect(errorResponse.jsonrpc).toBe('2.0');
+      expect(errorResponse.id).toBe(2);
+      expect(errorResponse.error).toBeDefined();
+    } finally {
+      await bridge?.kill();
+      await server?.kill();
+      if (configDir) cleanupTestConfigDir(configDir);
+    }
+  });
+});

--- a/platform/cli/src/commands/config.ts
+++ b/platform/cli/src/commands/config.ts
@@ -183,6 +183,8 @@ const PLUGIN_PERMISSION_PREFIX = 'plugin-permission.';
 const SETTING_PREFIX = 'setting.';
 const LOCAL_PLUGINS_ADD = 'localPlugins.add';
 const LOCAL_PLUGINS_REMOVE = 'localPlugins.remove';
+const ALLOWED_DIRS_ADD = 'allowedDirectories.add';
+const ALLOWED_DIRS_REMOVE = 'allowedDirectories.remove';
 const PORT_KEY = 'port';
 
 const SUPPORTED_KEYS = `Supported keys:
@@ -191,7 +193,9 @@ const SUPPORTED_KEYS = `Supported keys:
   setting.<plugin>.<key>            Set a plugin setting (e.g., setting.sqlpad.instanceUrl)
   port                              Set the server port (value: 1-65535)
   localPlugins.add                  Add a local plugin path (value: absolute or relative path)
-  localPlugins.remove               Remove a local plugin path (value: path to remove)`;
+  localPlugins.remove               Remove a local plugin path (value: path to remove)
+  allowedDirectories.add            Add an allowed directory for local plugins (value: absolute path)
+  allowedDirectories.remove         Remove an allowed directory (value: path to remove)`;
 
 const loadConfig = async (): Promise<{ config: Record<string, unknown>; configPath: string }> => {
   const configPath = getConfigPath();
@@ -470,6 +474,55 @@ const handleSetLocalPluginsRemove = async (value: string, options: { port?: numb
   await notifyServer({ port: options.port, warnIfNotRunning: true });
 };
 
+const handleSetAllowedDirsAdd = async (value: string, options: { port?: number }): Promise<void> => {
+  const expandedValue = value.startsWith('~/') ? join(homedir(), value.slice(2)) : value;
+  const dirPath = resolve(expandedValue);
+  const { config, configPath } = await loadConfig();
+
+  if (!Array.isArray(config.additionalAllowedDirectories)) {
+    config.additionalAllowedDirectories = [];
+  }
+  const dirs = config.additionalAllowedDirectories as string[];
+
+  if (dirs.includes(dirPath)) {
+    console.log(`${pc.dim('Already registered:')} ${dirPath}`);
+    return;
+  }
+
+  if (!existsSync(dirPath)) {
+    console.error(pc.red(`Error: Directory does not exist: ${dirPath}`));
+    process.exit(1);
+  }
+
+  dirs.push(dirPath);
+  await atomicWriteConfig(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  console.log(`${pc.green('Added allowed directory:')} ${dirPath}`);
+  await notifyServer({ port: options.port, warnIfNotRunning: true });
+};
+
+const handleSetAllowedDirsRemove = async (value: string, options: { port?: number }): Promise<void> => {
+  const expandedValue = value.startsWith('~/') ? join(homedir(), value.slice(2)) : value;
+  const dirPath = resolve(expandedValue);
+  const { config, configPath } = await loadConfig();
+
+  if (!Array.isArray(config.additionalAllowedDirectories)) {
+    console.error(pc.red(`Directory not found in allowedDirectories: ${dirPath}`));
+    process.exit(1);
+  }
+  const dirs = config.additionalAllowedDirectories as string[];
+  const index = dirs.findIndex(d => resolve(d) === dirPath);
+
+  if (index === -1) {
+    console.error(pc.red(`Directory not found in allowedDirectories: ${dirPath}`));
+    process.exit(1);
+  }
+
+  dirs.splice(index, 1);
+  await atomicWriteConfig(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  console.log(`${pc.green('Removed allowed directory:')} ${dirPath}`);
+  await notifyServer({ port: options.port, warnIfNotRunning: true });
+};
+
 const levenshtein = (a: string, b: string): number => {
   const n = b.length;
   let prev = Array.from({ length: n + 1 }, (_, j) => j);
@@ -492,6 +545,8 @@ const KNOWN_KEYS = [
   PORT_KEY,
   LOCAL_PLUGINS_ADD,
   LOCAL_PLUGINS_REMOVE,
+  ALLOWED_DIRS_ADD,
+  ALLOWED_DIRS_REMOVE,
 ];
 
 const suggestKey = (input: string): string | null => {
@@ -546,6 +601,12 @@ const handleConfigSet = async (
   }
   if (key === LOCAL_PLUGINS_REMOVE) {
     return handleSetLocalPluginsRemove(value, options);
+  }
+  if (key === ALLOWED_DIRS_ADD) {
+    return handleSetAllowedDirsAdd(value, options);
+  }
+  if (key === ALLOWED_DIRS_REMOVE) {
+    return handleSetAllowedDirsRemove(value, options);
   }
 
   console.error(pc.red(`Unknown config key: ${key}`));

--- a/platform/cli/src/commands/start.ts
+++ b/platform/cli/src/commands/start.ts
@@ -79,6 +79,7 @@ interface StartOptions {
   port?: number;
   showConfig?: boolean;
   background?: boolean;
+  stdio?: boolean;
 }
 
 const resolveServerEntry = (): string => {
@@ -258,7 +259,31 @@ const printMcpClientConfigs = (mcpUrl: string, secret: string | null, primaryOnl
     console.log('');
   }
 
-  // Section 3: CLI only
+  // Section 3: stdio bridge (auto-start)
+  console.log(
+    `${pad}${pc.bold('Auto-start via stdio')} ${pc.dim('(MCP client spawns the bridge — no manual server start):')}`,
+  );
+  console.log('');
+  console.log(pc.dim(`${pad}  ${pc.bold('Claude Code')} (~/.claude.json):`));
+  console.log(
+    pc.dim(
+      indent(
+        JSON.stringify(
+          {
+            mcpServers: {
+              opentabs: { command: 'opentabs', args: ['start', '--stdio'] },
+            },
+          },
+          null,
+          2,
+        ),
+        `${pad}  `,
+      ),
+    ),
+  );
+  console.log('');
+
+  // Section 4: CLI only
   console.log(`${pad}${pc.bold('CLI only')} ${pc.dim('(no MCP registration — use shell commands):')}`);
   console.log('');
   console.log(pc.dim(`${pad}  opentabs tool list                              ${pc.dim('# discover tools')}`));
@@ -286,6 +311,16 @@ const printMcpClientConfigs = (mcpUrl: string, secret: string | null, primaryOnl
 };
 
 const handleStart = async (options: StartOptions): Promise<void> => {
+  // stdio mode: run the bridge instead of starting a new server
+  if (options.stdio) {
+    if (options.background) {
+      console.error(pc.red('Error: --stdio and --background cannot be used together.'));
+      process.exit(1);
+    }
+    const { handleStdioBridge } = await import('./stdio-bridge.js');
+    return handleStdioBridge(resolvePort(options));
+  }
+
   const serverEntry = resolveServerEntry();
 
   if (
@@ -488,6 +523,7 @@ const registerStartCommand = (program: Command): void => {
     .description('Start the MCP server')
     .option('--port <number>', 'Server port (default: 9515)', parsePort)
     .option('--background', 'Start the server in the background')
+    .option('--stdio', 'Use stdio transport (bridge to existing HTTP server for MCP client auto-start)')
     .option('--show-config', 'Print MCP client configuration and exit without starting the server')
     .addHelpText(
       'after',
@@ -495,6 +531,7 @@ const registerStartCommand = (program: Command): void => {
 Examples:
   $ opentabs start
   $ opentabs start --background
+  $ opentabs start --stdio
   $ opentabs start --port 3000
   $ opentabs start --show-config
 

--- a/platform/cli/src/commands/stdio-bridge.ts
+++ b/platform/cli/src/commands/stdio-bridge.ts
@@ -231,10 +231,11 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
   };
 
   const rl = createInterface({ input: process.stdin });
+  const inflight = new Set<Promise<void>>();
 
   let buffer = '';
 
-  rl.on('line', async (line: string) => {
+  rl.on('line', (line: string) => {
     buffer += line;
 
     let parsed: unknown;
@@ -251,6 +252,7 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
 
     log(`-> ${method ?? 'response'}${isNotification ? ' (notification)' : ''}`);
 
+    const work = (async () => {
     try {
       const response = await fetch(mcpUrl, {
         method: 'POST',
@@ -300,15 +302,21 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
         process.stdout.write(`${errorResponse}\n`);
       }
     }
+    })();
+    inflight.add(work);
+    work.finally(() => inflight.delete(work));
   });
 
-  // stdin EOF = MCP client disconnected
+  // stdin EOF = MCP client disconnected; wait for in-flight requests to finish
   await new Promise<void>(resolve => {
     rl.on('close', () => {
-      log('stdin closed, shutting down bridge');
+      log('stdin closed, waiting for in-flight requests...');
       resolve();
     });
   });
+  if (inflight.size > 0) {
+    await Promise.allSettled(inflight);
+  }
 
   // Clean up: abort notification stream and delete session
   notificationAbort.abort();

--- a/platform/cli/src/commands/stdio-bridge.ts
+++ b/platform/cli/src/commands/stdio-bridge.ts
@@ -24,6 +24,33 @@ import { createInterface } from 'node:readline';
 import { DEFAULT_PORT } from '@opentabs-dev/shared';
 import { ensureAuthSecret, getConfigDir } from '../config.js';
 
+// ---------------------------------------------------------------------------
+// Sequential stdout writer — prevents interleaving when the notification
+// stream reader and POST response handler write concurrently.
+// ---------------------------------------------------------------------------
+
+type StdoutWriter = (data: string) => void;
+
+const createStdoutWriter = (): StdoutWriter => {
+  const queue: string[] = [];
+  let draining = false;
+
+  const drain = (): void => {
+    if (draining) return;
+    draining = true;
+    while (queue.length > 0) {
+      const item = queue.shift();
+      if (item !== undefined) process.stdout.write(item);
+    }
+    draining = false;
+  };
+
+  return (data: string) => {
+    queue.push(data);
+    drain();
+  };
+};
+
 const getLogsDir = (): string => join(getConfigDir(), 'logs');
 
 const getStdioBridgeLogPath = async (): Promise<string> => {
@@ -126,66 +153,109 @@ const extractDataFromSse = (body: string): string[] => {
  * Open a long-running GET SSE stream for server-initiated notifications.
  * The MCP Streamable HTTP spec sends tools/list_changed, logging, and other
  * server notifications over a standalone GET stream (not as POST responses).
+ *
+ * Reconnects automatically with exponential backoff if the stream drops
+ * unexpectedly (e.g., server restart during hot reload, network hiccup).
  */
 const openNotificationStream = (
   mcpUrl: string,
   sessionId: string,
   secret: string,
   log: LogFn,
+  writeStdout: StdoutWriter,
   abortController: AbortController,
 ): void => {
-  const streamUrl = mcpUrl;
-  const doOpen = async (): Promise<void> => {
-    try {
-      const response = await fetch(streamUrl, {
-        method: 'GET',
-        headers: {
-          Accept: 'text/event-stream',
-          Authorization: `Bearer ${secret}`,
-          'Mcp-Session-Id': sessionId,
-        },
-        signal: abortController.signal,
-      });
+  const MAX_BACKOFF_MS = 30_000;
+  const INITIAL_BACKOFF_MS = 1_000;
 
-      if (!response.ok || !response.body) {
-        log(`Notification stream failed: ${String(response.status)}`);
-        return;
-      }
+  const connect = async (): Promise<void> => {
+    let backoff = INITIAL_BACKOFF_MS;
 
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let sseBuffer = '';
+    while (!abortController.signal.aborted) {
+      try {
+        const response = await fetch(mcpUrl, {
+          method: 'GET',
+          headers: {
+            Accept: 'text/event-stream',
+            Authorization: `Bearer ${secret}`,
+            'Mcp-Session-Id': sessionId,
+          },
+          signal: abortController.signal,
+        });
 
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
+        if (!response.ok || !response.body) {
+          log(`Notification stream failed: ${String(response.status)}, retrying in ${String(backoff)}ms`);
+          if (abortController.signal.aborted) return;
+          await new Promise<void>(resolve => {
+            const timer = setTimeout(resolve, backoff);
+            abortController.signal.addEventListener(
+              'abort',
+              () => {
+                clearTimeout(timer);
+                resolve();
+              },
+              { once: true },
+            );
+          });
+          backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+          continue;
+        }
 
-        sseBuffer += decoder.decode(value, { stream: true });
+        // Connected successfully — reset backoff
+        backoff = INITIAL_BACKOFF_MS;
+        log('Notification stream connected');
 
-        // Process complete SSE events (separated by double newlines)
-        const events = sseBuffer.split('\n\n');
-        sseBuffer = events.pop() ?? '';
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let sseBuffer = '';
 
-        for (const event of events) {
-          for (const line of event.split('\n')) {
-            if (line.startsWith('data: ')) {
-              const data = line.slice(6).trim();
-              if (data) {
-                process.stdout.write(`${data}\n`);
-                log(`<< notification: ${data.slice(0, 100)}${data.length > 100 ? '...' : ''}`);
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          sseBuffer += decoder.decode(value, { stream: true });
+
+          const events = sseBuffer.split('\n\n');
+          sseBuffer = events.pop() ?? '';
+
+          for (const event of events) {
+            for (const line of event.split('\n')) {
+              if (line.startsWith('data: ')) {
+                const data = line.slice(6).trim();
+                if (data) {
+                  writeStdout(`${data}\n`);
+                  log(`<< notification: ${data.slice(0, 100)}${data.length > 100 ? '...' : ''}`);
+                }
               }
             }
           }
         }
+
+        // Stream ended without abort — reconnect
+        if (!abortController.signal.aborted) {
+          log(`Notification stream ended unexpectedly, reconnecting in ${String(backoff)}ms`);
+        }
+      } catch (error: unknown) {
+        if (abortController.signal.aborted) return;
+        const msg = error instanceof Error ? error.message : String(error);
+        log(`Notification stream error: ${msg}, reconnecting in ${String(backoff)}ms`);
       }
-    } catch (error: unknown) {
+
+      // Wait before reconnecting — abort-aware so shutdown is prompt
       if (abortController.signal.aborted) return;
-      const msg = error instanceof Error ? error.message : String(error);
-      log(`Notification stream error: ${msg}`);
+      await new Promise<void>(resolve => {
+        const timer = setTimeout(resolve, backoff);
+        const onAbort = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        abortController.signal.addEventListener('abort', onAbort, { once: true });
+      });
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
     }
   };
 
-  doOpen().catch(() => {});
+  connect().catch(() => {});
 };
 
 /**
@@ -219,6 +289,7 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
   const mcpUrl = `http://127.0.0.1:${String(port)}/mcp`;
   let sessionId: string | null = null;
   const notificationAbort = new AbortController();
+  const writeStdout = createStdoutWriter();
 
   const baseHeaders = (): Record<string, string> => {
     const h: Record<string, string> = {
@@ -275,7 +346,7 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
             log(`Session established: ${sessionId}`);
 
             // Now that we have a session, open the notification stream
-            openNotificationStream(mcpUrl, sessionId, secret, log, notificationAbort);
+            openNotificationStream(mcpUrl, sessionId, secret, log, writeStdout, notificationAbort);
           }
         }
 
@@ -288,11 +359,11 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
 
         if (contentType.includes('text/event-stream')) {
           for (const data of extractDataFromSse(body)) {
-            process.stdout.write(`${data}\n`);
+            writeStdout(`${data}\n`);
             log(`<- ${data.slice(0, 100)}${data.length > 100 ? '...' : ''}`);
           }
         } else if (body.trim()) {
-          process.stdout.write(`${body}\n`);
+          writeStdout(`${body}\n`);
           log(`<- ${body.slice(0, 100)}${body.length > 100 ? '...' : ''}`);
         }
       } catch (error: unknown) {
@@ -305,7 +376,7 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
             id: message.id,
             error: { code: -32603, message: `Bridge proxy error: ${errorMessage}` },
           });
-          process.stdout.write(`${errorResponse}\n`);
+          writeStdout(`${errorResponse}\n`);
         }
       }
     })();

--- a/platform/cli/src/commands/stdio-bridge.ts
+++ b/platform/cli/src/commands/stdio-bridge.ts
@@ -1,0 +1,354 @@
+/**
+ * stdio-to-HTTP bridge for MCP clients that spawn the server as a child process.
+ *
+ * Instead of starting a second MCP server (which would conflict on the port),
+ * this bridge connects to an existing HTTP server:
+ *
+ * 1. Check if the server is already running on the target port
+ * 2. If not, start it in the background and wait for health
+ * 3. Transparently proxy JSON-RPC from stdin to POST /mcp, responses to stdout
+ * 4. Open a GET SSE stream for server-initiated notifications (tools/list_changed, logging)
+ * 5. On stdin EOF, send DELETE /mcp to clean up the session, then exit
+ *
+ * The bridge does NOT pre-initialize -- it lets the client's own `initialize`
+ * request pass through and captures the Mcp-Session-Id from the response.
+ *
+ * All diagnostic output goes to a log file and stderr -- never stdout,
+ * which is reserved exclusively for the MCP protocol.
+ */
+
+import { createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import { DEFAULT_PORT } from '@opentabs-dev/shared';
+import { ensureAuthSecret, getConfigDir } from '../config.js';
+
+const getLogsDir = (): string => join(getConfigDir(), 'logs');
+
+const getStdioBridgeLogPath = async (): Promise<string> => {
+  const logsDir = getLogsDir();
+  await mkdir(logsDir, { recursive: true, mode: 0o700 });
+  return join(logsDir, 'stdio-bridge.log');
+};
+
+type LogFn = (message: string) => void;
+
+const createLogger = (logPath: string): { log: LogFn; close: () => void } => {
+  const stream = createWriteStream(logPath, { flags: 'a', mode: 0o600 });
+  const log: LogFn = (message: string) => {
+    const ts = new Date().toISOString();
+    const line = `[stdio-bridge] ${ts} ${message}\n`;
+    stream.write(line);
+    process.stderr.write(line);
+  };
+  return { log, close: () => stream.end() };
+};
+
+const waitForHealth = async (port: number, secret: string, log: LogFn, maxWaitMs = 15_000): Promise<boolean> => {
+  const url = `http://127.0.0.1:${String(port)}/health`;
+  const start = Date.now();
+  const interval = 500;
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${secret}` },
+        signal: AbortSignal.timeout(2000),
+      });
+      if (response.ok) return true;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+  log(`Server did not become healthy within ${String(maxWaitMs)}ms`);
+  return false;
+};
+
+const isServerRunning = async (port: number): Promise<boolean> => {
+  try {
+    const response = await fetch(`http://127.0.0.1:${String(port)}/health`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
+const startBackgroundServer = async (port: number, log: LogFn): Promise<boolean> => {
+  const { spawn } = await import('node:child_process');
+  log(`Starting background server on port ${String(port)}...`);
+
+  const cliEntry = process.argv[1] ?? 'opentabs';
+  const child = spawn(process.execPath, [cliEntry, 'start', '--background', '--port', String(port)], {
+    stdio: ['ignore', 'ignore', 'ignore'],
+    detached: true,
+    env: { ...process.env, PORT: String(port) },
+  });
+  child.unref();
+
+  const crashed = await new Promise<boolean>(resolve => {
+    const timer = setTimeout(() => {
+      child.removeAllListeners('exit');
+      resolve(false);
+    }, 3000);
+    child.on('exit', () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+
+  if (crashed) {
+    log('Background server exited unexpectedly');
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Extract all JSON data lines from an SSE response body.
+ * SSE format: "event: message\ndata: {...}\n\n"
+ */
+const extractDataFromSse = (body: string): string[] => {
+  const results: string[] = [];
+  for (const line of body.split('\n')) {
+    if (line.startsWith('data: ')) {
+      const data = line.slice(6).trim();
+      if (data) results.push(data);
+    }
+  }
+  return results;
+};
+
+/**
+ * Open a long-running GET SSE stream for server-initiated notifications.
+ * The MCP Streamable HTTP spec sends tools/list_changed, logging, and other
+ * server notifications over a standalone GET stream (not as POST responses).
+ */
+const openNotificationStream = (
+  mcpUrl: string,
+  sessionId: string,
+  secret: string,
+  log: LogFn,
+  abortController: AbortController,
+): void => {
+  const streamUrl = mcpUrl;
+  const doOpen = async (): Promise<void> => {
+    try {
+      const response = await fetch(streamUrl, {
+        method: 'GET',
+        headers: {
+          Accept: 'text/event-stream',
+          Authorization: `Bearer ${secret}`,
+          'Mcp-Session-Id': sessionId,
+        },
+        signal: abortController.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        log(`Notification stream failed: ${String(response.status)}`);
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let sseBuffer = '';
+
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        sseBuffer += decoder.decode(value, { stream: true });
+
+        // Process complete SSE events (separated by double newlines)
+        const events = sseBuffer.split('\n\n');
+        sseBuffer = events.pop() ?? '';
+
+        for (const event of events) {
+          for (const line of event.split('\n')) {
+            if (line.startsWith('data: ')) {
+              const data = line.slice(6).trim();
+              if (data) {
+                process.stdout.write(`${data}\n`);
+                log(`<< notification: ${data.slice(0, 100)}...`);
+              }
+            }
+          }
+        }
+      }
+    } catch (error: unknown) {
+      if (abortController.signal.aborted) return;
+      const msg = error instanceof Error ? error.message : String(error);
+      log(`Notification stream error: ${msg}`);
+    }
+  };
+
+  doOpen().catch(() => {});
+};
+
+/**
+ * Send DELETE /mcp to clean up the HTTP session on disconnect.
+ */
+const deleteSession = async (mcpUrl: string, sessionId: string, secret: string, log: LogFn): Promise<void> => {
+  try {
+    await fetch(mcpUrl, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        'Mcp-Session-Id': sessionId,
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+    log('Session deleted');
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log(`Failed to delete session: ${msg}`);
+  }
+};
+
+/**
+ * Main bridge loop: transparently proxy JSON-RPC between stdin/stdout and HTTP /mcp.
+ *
+ * The bridge does NOT pre-initialize. The client sends its own `initialize` request,
+ * which the bridge forwards to the server. The bridge captures the Mcp-Session-Id
+ * from the response and uses it for all subsequent requests.
+ */
+const runBridge = async (port: number, secret: string, log: LogFn): Promise<void> => {
+  const mcpUrl = `http://127.0.0.1:${String(port)}/mcp`;
+  let sessionId: string | null = null;
+  const notificationAbort = new AbortController();
+
+  const baseHeaders = (): Record<string, string> => {
+    const h: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Authorization: `Bearer ${secret}`,
+    };
+    if (sessionId) h['Mcp-Session-Id'] = sessionId;
+    return h;
+  };
+
+  const rl = createInterface({ input: process.stdin });
+
+  let buffer = '';
+
+  rl.on('line', async (line: string) => {
+    buffer += line;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(buffer);
+    } catch {
+      return;
+    }
+    buffer = '';
+
+    const message = parsed as Record<string, unknown>;
+    const isNotification = !('id' in message);
+    const method = message.method as string | undefined;
+
+    log(`-> ${method ?? 'response'}${isNotification ? ' (notification)' : ''}`);
+
+    try {
+      const response = await fetch(mcpUrl, {
+        method: 'POST',
+        headers: baseHeaders(),
+        body: JSON.stringify(parsed),
+        signal: AbortSignal.timeout(300_000),
+      });
+
+      // Capture session ID from the initialize response
+      if (method === 'initialize' && !sessionId) {
+        const newSessionId = response.headers.get('mcp-session-id');
+        if (newSessionId) {
+          sessionId = newSessionId;
+          log(`Session established: ${sessionId}`);
+
+          // Now that we have a session, open the notification stream
+          openNotificationStream(mcpUrl, sessionId, secret, log, notificationAbort);
+        }
+      }
+
+      if (isNotification) {
+        return;
+      }
+
+      const body = await response.text();
+
+      // SSE responses contain one or more "data: {...}" lines
+      if (body.includes('event: ') || body.includes('data: ')) {
+        for (const data of extractDataFromSse(body)) {
+          process.stdout.write(`${data}\n`);
+          log(`<- ${data.slice(0, 100)}...`);
+        }
+      } else if (body.trim()) {
+        process.stdout.write(`${body}\n`);
+        log(`<- ${body.slice(0, 100)}...`);
+      }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      log(`Error proxying request: ${errorMessage}`);
+
+      if ('id' in message) {
+        const errorResponse = JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32603, message: `Bridge proxy error: ${errorMessage}` },
+        });
+        process.stdout.write(`${errorResponse}\n`);
+      }
+    }
+  });
+
+  // stdin EOF = MCP client disconnected
+  await new Promise<void>(resolve => {
+    rl.on('close', () => {
+      log('stdin closed, shutting down bridge');
+      resolve();
+    });
+  });
+
+  // Clean up: abort notification stream and delete session
+  notificationAbort.abort();
+  if (sessionId) {
+    await deleteSession(mcpUrl, sessionId, secret, log);
+  }
+};
+
+/**
+ * Entry point for `opentabs start --stdio`.
+ */
+export const handleStdioBridge = async (port?: number): Promise<void> => {
+  const targetPort = port ?? DEFAULT_PORT;
+  const logPath = await getStdioBridgeLogPath();
+  const { log, close: closeLog } = createLogger(logPath);
+
+  log(`Bridge starting (target port: ${String(targetPort)})`);
+
+  const secret = await ensureAuthSecret();
+
+  const running = await isServerRunning(targetPort);
+  if (!running) {
+    log('Server not running, starting in background...');
+    const started = await startBackgroundServer(targetPort, log);
+    if (!started) {
+      log('Failed to start background server');
+      process.exit(1);
+    }
+    const healthy = await waitForHealth(targetPort, secret, log);
+    if (!healthy) {
+      log('Server failed health check after background start');
+      process.exit(1);
+    }
+    log('Background server is healthy');
+  } else {
+    log('Server already running');
+  }
+
+  await runBridge(targetPort, secret, log);
+
+  log('Bridge exiting');
+  closeLog();
+};

--- a/platform/cli/src/commands/stdio-bridge.ts
+++ b/platform/cli/src/commands/stdio-bridge.ts
@@ -88,7 +88,7 @@ const startBackgroundServer = async (port: number, log: LogFn): Promise<boolean>
   });
   child.unref();
 
-  const crashed = await new Promise<boolean>(resolve => {
+  const exitedEarly = await new Promise<boolean>(resolve => {
     const timer = setTimeout(() => {
       child.removeAllListeners('exit');
       resolve(false);
@@ -99,7 +99,7 @@ const startBackgroundServer = async (port: number, log: LogFn): Promise<boolean>
     });
   });
 
-  if (crashed) {
+  if (exitedEarly) {
     log('Background server exited unexpectedly');
     return false;
   }
@@ -172,7 +172,7 @@ const openNotificationStream = (
               const data = line.slice(6).trim();
               if (data) {
                 process.stdout.write(`${data}\n`);
-                log(`<< notification: ${data.slice(0, 100)}...`);
+                log(`<< notification: ${data.slice(0, 100)}${data.length > 100 ? '...' : ''}`);
               }
             }
           }
@@ -233,10 +233,16 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
   const rl = createInterface({ input: process.stdin });
   const inflight = new Set<Promise<void>>();
 
+  const MAX_BUFFER = 10 * 1024 * 1024;
   let buffer = '';
 
   rl.on('line', (line: string) => {
     buffer += line;
+    if (buffer.length > MAX_BUFFER) {
+      log('Buffer overflow, resetting');
+      buffer = '';
+      return;
+    }
 
     let parsed: unknown;
     try {
@@ -253,55 +259,55 @@ const runBridge = async (port: number, secret: string, log: LogFn): Promise<void
     log(`-> ${method ?? 'response'}${isNotification ? ' (notification)' : ''}`);
 
     const work = (async () => {
-    try {
-      const response = await fetch(mcpUrl, {
-        method: 'POST',
-        headers: baseHeaders(),
-        body: JSON.stringify(parsed),
-        signal: AbortSignal.timeout(300_000),
-      });
-
-      // Capture session ID from the initialize response
-      if (method === 'initialize' && !sessionId) {
-        const newSessionId = response.headers.get('mcp-session-id');
-        if (newSessionId) {
-          sessionId = newSessionId;
-          log(`Session established: ${sessionId}`);
-
-          // Now that we have a session, open the notification stream
-          openNotificationStream(mcpUrl, sessionId, secret, log, notificationAbort);
-        }
-      }
-
-      if (isNotification) {
-        return;
-      }
-
-      const body = await response.text();
-
-      // SSE responses contain one or more "data: {...}" lines
-      if (body.includes('event: ') || body.includes('data: ')) {
-        for (const data of extractDataFromSse(body)) {
-          process.stdout.write(`${data}\n`);
-          log(`<- ${data.slice(0, 100)}...`);
-        }
-      } else if (body.trim()) {
-        process.stdout.write(`${body}\n`);
-        log(`<- ${body.slice(0, 100)}...`);
-      }
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      log(`Error proxying request: ${errorMessage}`);
-
-      if ('id' in message) {
-        const errorResponse = JSON.stringify({
-          jsonrpc: '2.0',
-          id: message.id,
-          error: { code: -32603, message: `Bridge proxy error: ${errorMessage}` },
+      try {
+        const response = await fetch(mcpUrl, {
+          method: 'POST',
+          headers: baseHeaders(),
+          body: JSON.stringify(parsed),
+          signal: AbortSignal.timeout(300_000),
         });
-        process.stdout.write(`${errorResponse}\n`);
+
+        // Capture session ID from the initialize response
+        if (method === 'initialize' && !sessionId) {
+          const newSessionId = response.headers.get('mcp-session-id');
+          if (newSessionId) {
+            sessionId = newSessionId;
+            log(`Session established: ${sessionId}`);
+
+            // Now that we have a session, open the notification stream
+            openNotificationStream(mcpUrl, sessionId, secret, log, notificationAbort);
+          }
+        }
+
+        if (isNotification) {
+          return;
+        }
+
+        const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
+        const body = await response.text();
+
+        if (contentType.includes('text/event-stream')) {
+          for (const data of extractDataFromSse(body)) {
+            process.stdout.write(`${data}\n`);
+            log(`<- ${data.slice(0, 100)}${data.length > 100 ? '...' : ''}`);
+          }
+        } else if (body.trim()) {
+          process.stdout.write(`${body}\n`);
+          log(`<- ${body.slice(0, 100)}${body.length > 100 ? '...' : ''}`);
+        }
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        log(`Error proxying request: ${errorMessage}`);
+
+        if ('id' in message) {
+          const errorResponse = JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            error: { code: -32603, message: `Bridge proxy error: ${errorMessage}` },
+          });
+          process.stdout.write(`${errorResponse}\n`);
+        }
       }
-    }
     })();
     inflight.add(work);
     work.finally(() => inflight.delete(work));

--- a/platform/mcp-server/src/config.ts
+++ b/platform/mcp-server/src/config.ts
@@ -46,6 +46,8 @@ interface OpentabsConfig {
   permissions: Record<string, PluginPermissionConfig>;
   /** Per-plugin settings: plugin name → { settingKey: value } */
   settings: Record<string, Record<string, unknown>>;
+  /** Extra directories where local plugins may reside (extends the default homedir/tmpdir/cwd roots) */
+  additionalAllowedDirectories?: string[];
 }
 
 /** Version marker file for the managed extension install */
@@ -176,7 +178,11 @@ const parseConfigRecord = (record: Record<string, unknown>): OpentabsConfig => {
   const permissions = parsePluginsConfig(record.permissions);
   const settings = parseSettingsConfig(record.settings);
 
-  return { localPlugins, permissions, settings };
+  const additionalAllowedDirectories = Array.isArray(record.additionalAllowedDirectories)
+    ? (record.additionalAllowedDirectories as unknown[]).filter((p): p is string => typeof p === 'string')
+    : [];
+
+  return { localPlugins, permissions, settings, additionalAllowedDirectories };
 };
 
 /**
@@ -204,6 +210,7 @@ const loadConfig = async (): Promise<OpentabsConfig> => {
       localPlugins: [],
       permissions: {},
       settings: {},
+      additionalAllowedDirectories: [],
     };
     await atomicWriteConfig(configPath, `${JSON.stringify(config, null, 2)}\n`);
     log.info(`Created default config at ${configPath}`);
@@ -272,6 +279,7 @@ const savePluginPermissions = async (
       localPlugins: current.localPlugins,
       permissions: plugins,
       settings: current.settings,
+      additionalAllowedDirectories: current.additionalAllowedDirectories,
     };
     await atomicWriteConfig(configPath, `${JSON.stringify(updated, null, 2)}\n`);
   })();
@@ -311,6 +319,7 @@ const savePluginSettings = async (
       localPlugins: current.localPlugins,
       permissions: current.permissions,
       settings,
+      additionalAllowedDirectories: current.additionalAllowedDirectories,
     };
     await atomicWriteConfig(configPath, `${JSON.stringify(updated, null, 2)}\n`);
   })();

--- a/platform/mcp-server/src/discovery.ts
+++ b/platform/mcp-server/src/discovery.ts
@@ -35,6 +35,7 @@ const discoverPlugins = async (
   localPlugins: string[],
   configDir: string,
   pluginSettings?: Record<string, Record<string, unknown>>,
+  additionalAllowedDirs?: readonly string[],
 ): Promise<DiscoveryResult> => {
   log.info('Starting plugin discovery...');
 
@@ -61,7 +62,7 @@ const discoverPlugins = async (
   });
 
   const loadLocal = localPlugins.map(async (specifier): Promise<LoadedPlugin | null> => {
-    const resolveResult = await resolvePluginPath(specifier, configDir);
+    const resolveResult = await resolvePluginPath(specifier, configDir, additionalAllowedDirs);
     if (isErr(resolveResult)) {
       // "Path not found" means the directory no longer exists — treat as a stale config
       // entry and skip silently (only log, don't add to failedPlugins).

--- a/platform/mcp-server/src/reload.ts
+++ b/platform/mcp-server/src/reload.ts
@@ -258,7 +258,12 @@ const reloadCore = async ({ state, sessionServers, transports }: ReloadCoreArgs)
   try {
     const config = await loadConfig();
     const configDir = getConfigDir();
-    const { registry, errors } = await discoverPlugins(config.localPlugins, configDir, config.settings);
+    const { registry, errors } = await discoverPlugins(
+      config.localPlugins,
+      configDir,
+      config.settings,
+      config.additionalAllowedDirectories ?? [],
+    );
 
     // Compute all new state values locally before touching state.
     // This ensures an atomic swap: if any step throws, state retains its previous values.

--- a/platform/mcp-server/src/resolver.ts
+++ b/platform/mcp-server/src/resolver.ts
@@ -23,7 +23,12 @@ import { log } from './logger.js';
  * Plugins must reside under the user's home directory or the system temp directory.
  * The temp directory allowance supports E2E tests and development workflows.
  */
-const getAllowedRoots = (): string[] => [homedir(), tmpdir(), process.cwd()];
+const getAllowedRoots = (extraDirs: readonly string[] = []): string[] => [
+  homedir(),
+  tmpdir(),
+  process.cwd(),
+  ...extraDirs,
+];
 
 /**
  * Resolve a path to its canonical form, following symlinks.
@@ -44,9 +49,12 @@ const safeRealpath = async (path: string): Promise<string> => {
  * Checks against both raw and resolved roots to handle non-existent paths
  * where realpath falls back to the unresolved input.
  */
-const isAllowedPluginPath = async (resolvedPath: string): Promise<boolean> => {
+const isAllowedPluginPath = async (
+  resolvedPath: string,
+  extraAllowedDirs: readonly string[] = [],
+): Promise<boolean> => {
   const realPath = await safeRealpath(resolvedPath);
-  const rawRoots = getAllowedRoots();
+  const rawRoots = getAllowedRoots(extraAllowedDirs);
   const realRoots = await Promise.all(rawRoots.map(safeRealpath));
 
   // Deduplicate: on macOS, raw /var/... and resolved /private/var/... differ
@@ -112,11 +120,15 @@ const resolveNpmPackage = (specifier: string): Result<string, string> => {
  *
  * Returns the directory path containing the plugin's package.json.
  */
-const resolvePluginPath = async (specifier: string, configDir: string): Promise<Result<string, string>> => {
+const resolvePluginPath = async (
+  specifier: string,
+  configDir: string,
+  extraAllowedDirs: readonly string[] = [],
+): Promise<Result<string, string>> => {
   if (isLocalPath(specifier)) {
     const resolvedPath = resolveLocalPath(specifier, configDir);
 
-    if (!(await isAllowedPluginPath(resolvedPath))) {
+    if (!(await isAllowedPluginPath(resolvedPath, extraAllowedDirs))) {
       return err(`Path outside allowed directories: ${resolvedPath}`);
     }
 


### PR DESCRIPTION
## Summary

Two features for better MCP client integration and local plugin development:

### 1. `opentabs start --stdio` -- MCP client auto-start
- Thin stdio-to-HTTP bridge that lets MCP clients (Claude Code, etc.) spawn OpenTabs as a child process
- Transparently proxies MCP JSON-RPC between stdin/stdout and the existing HTTP server
- Auto-starts the server in background if not already running
- Opens GET SSE stream for server-push notifications (tools/list_changed, logging)
- Sends DELETE /mcp on stdin EOF to clean up the HTTP session
- Logs to `~/.opentabs/logs/stdio-bridge.log`
- No port conflicts, no stdout contamination (bridge has zero deps writing to stdout)

### 2. `additionalAllowedDirectories` config
- Allows local plugins to reside outside the default homedir/tmpdir/cwd roots
- Configured via `opentabs config set allowedDirectories.add <path>`
- Extra dirs are threaded through function parameters (no module-level mutable state)
- Preserved across permission and settings saves

## MCP Client Config (stdio)

```json
{
  "mcpServers": {
    "opentabs": {
      "command": "node",
      "args": ["/path/to/opentabs/platform/cli/dist/cli.js", "start", "--stdio"]
    }
  }
}
```

Or with global install:
```json
{
  "mcpServers": {
    "opentabs": { "command": "opentabs", "args": ["start", "--stdio"] }
  }
}
```

## Allowed Directories Config

```bash
opentabs config set allowedDirectories.add "D:\Code Check"
opentabs config set allowedDirectories.remove "D:\Code Check"
```

## Test plan

- [x] Build passes (tsc --build)
- [x] Lint passes (biome)
- [x] All 3418 unit tests pass
- [x] Manual test: stdio bridge initialize + tools/list + session cleanup
- [x] Log persistence verified (~/.opentabs/logs/stdio-bridge.log)
- [x] Pre-push hooks pass (lint + build + test)
- [x] E2E test with Claude Code as MCP client
- [x] Test additionalAllowedDirectories with real plugin loading
- [ ] Test on macOS/Linux