### PR TITLE
fix: resolve 'entries is not iterable' crash in analyze_site and extension_get_logs

### DIFF
--- a/platform/mcp-server/src/browser-tools/analyze-site/index.ts
+++ b/platform/mcp-server/src/browser-tools/analyze-site/index.ts
@@ -918,9 +918,15 @@ const analyzeSite = async (
     };
     let storageKeys = defaultStorageKeys;
     try {
-      storageKeys =
-        ((await executeInTab(state, tabId, STORAGE_KEYS_SCRIPT)) as typeof defaultStorageKeys | null) ??
-        defaultStorageKeys;
+      const rawStorageKeys = await executeInTab(state, tabId, STORAGE_KEYS_SCRIPT);
+      if (rawStorageKeys !== null && typeof rawStorageKeys === 'object' && !Array.isArray(rawStorageKeys)) {
+        const obj = rawStorageKeys as Record<string, unknown>;
+        storageKeys = {
+          cookieNames: Array.isArray(obj.cookieNames) ? (obj.cookieNames as string[]) : [],
+          localStorageKeys: Array.isArray(obj.localStorageKeys) ? (obj.localStorageKeys as string[]) : [],
+          sessionStorageKeys: Array.isArray(obj.sessionStorageKeys) ? (obj.sessionStorageKeys as string[]) : [],
+        };
+      }
     } catch {
       // Partial analysis: storage keys detection skipped
     }
@@ -931,9 +937,14 @@ const analyzeSite = async (
     };
     let storageEntries = defaultStorageEntries;
     try {
-      storageEntries =
-        ((await executeInTab(state, tabId, STORAGE_ENTRIES_SCRIPT)) as typeof defaultStorageEntries | null) ??
-        defaultStorageEntries;
+      const rawStorageEntries = await executeInTab(state, tabId, STORAGE_ENTRIES_SCRIPT);
+      if (rawStorageEntries !== null && typeof rawStorageEntries === 'object' && !Array.isArray(rawStorageEntries)) {
+        const obj = rawStorageEntries as Record<string, unknown>;
+        storageEntries = {
+          localEntries: Array.isArray(obj.localEntries) ? (obj.localEntries as StorageEntry[]) : [],
+          sessionEntries: Array.isArray(obj.sessionEntries) ? (obj.sessionEntries as StorageEntry[]) : [],
+        };
+      }
     } catch {
       // Partial analysis: storage entries detection skipped
     }

--- a/platform/mcp-server/src/browser-tools/extension-get-logs.ts
+++ b/platform/mcp-server/src/browser-tools/extension-get-logs.ts
@@ -57,7 +57,7 @@ const extensionGetLogs = defineBrowserTool({
 
     for (const r of results) {
       const data = r.result as LogsResult;
-      if (data?.entries) {
+      if (Array.isArray(data?.entries)) {
         for (const entry of data.entries) {
           mergedEntries.push({ ...entry, connectionId: r.connectionId });
         }


### PR DESCRIPTION
## Summary

Two related bugs both manifesting as `Browser tool error: entries is not iterable`.

### `plugin_analyze_site` crash (primary bug)

When a page's `localStorage` or `sessionStorage` contains large data (>50KB total), `STORAGE_ENTRIES_SCRIPT`'s JSON result exceeds the extension's `EXEC_RESULT_TRUNCATION_LIMIT` and gets truncated to a string like `'{"localEntries":[...] (truncated)'`.

The existing guard `(result as T | null) ?? defaultStorageEntries` only catches `null`/`undefined` — a non-null string passes right through. `storageEntries` then becomes a string, `storageEntries.localEntries` is `undefined`, and `detectJwtInStorage(undefined, 'local')` throws `"entries is not iterable"` (V8 names the error after the parameter, which is called `entries`).

Fix: replace the naive cast+nullish-coalesce with explicit shape validation — check that the result is a plain object and that each expected property is actually an array before using it. Falls back to the empty defaults otherwise. Applied to both `storageKeys` and `storageEntries`.

### `extension_get_logs` defensive hardening (secondary)

`if (data?.entries)` is truthy even when `data` is an array, because `Array.prototype.entries` is a function. Iterating a function named `entries` throws the same error. Changed to `if (Array.isArray(data?.entries))`.

## Test plan

- [ ] Open `plugin_analyze_site` on a site with heavy `localStorage` usage (e.g. a SPA that caches API responses) and confirm it returns results rather than crashing
- [ ] Call `extension_get_logs` and confirm it returns merged log entries normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)