### PR TITLE
fix: move pluginNameFromPackage to shared and use it in build tool

### DIFF
--- a/platform/mcp-server/src/discovery.test.ts
+++ b/platform/mcp-server/src/discovery.test.ts
@@ -1,5 +1,6 @@
+import { pluginNameFromPackage } from '@opentabs-dev/shared';
 import { describe, expect, test } from 'vitest';
-import { checkBrowserToolReferences, pluginNameFromPackage } from './loader.js';
+import { checkBrowserToolReferences } from './loader.js';
 
 describe('pluginNameFromPackage', () => {
   test('strips opentabs-plugin- prefix from unscoped package', () => {

--- a/platform/mcp-server/src/loader.ts
+++ b/platform/mcp-server/src/loader.ts
@@ -18,8 +18,8 @@ import {
   BROWSER_TOOLS_CATALOG,
   err,
   ok,
-  PLUGIN_PREFIX,
   parsePluginPackageJson,
+  pluginNameFromPackage,
   TOOLS_FILENAME,
   validatePluginName,
   validateUrlPattern,
@@ -64,32 +64,6 @@ interface LoadedPlugin {
   /** Optional config schema from tools.json manifest */
   readonly configSchema: ConfigSchema | undefined;
 }
-
-/**
- * Extract the internal plugin name from an npm package name.
- *
- * Unscoped:                opentabs-plugin-slack                      → slack
- * Official @opentabs-dev:  @opentabs-dev/opentabs-plugin-e2e-test     → e2e-test
- * Third-party scope:       @myorg/opentabs-plugin-jira                → myorg-jira
- */
-const pluginNameFromPackage = (pkgName: string): string => {
-  const prefixPattern = new RegExp(`^${PLUGIN_PREFIX}`);
-  if (pkgName.startsWith('@')) {
-    const parts = pkgName.split('/');
-    const scopePart = parts[0] ?? '';
-    const namePart = parts[1] ?? '';
-    const pluginSuffix = namePart.replace(prefixPattern, '');
-
-    // Official scope is invisible — treat like an unscoped package
-    if (scopePart === '@opentabs-dev') {
-      return pluginSuffix;
-    }
-
-    const scope = scopePart.slice(1);
-    return `${scope}-${pluginSuffix}`;
-  }
-  return pkgName.replace(prefixPattern, '');
-};
 
 /**
  * Check plugin tool descriptions for references to browser tool names.

--- a/platform/plugin-tools/src/commands/build.ts
+++ b/platform/plugin-tools/src/commands/build.ts
@@ -25,6 +25,7 @@ import {
   getConfigDir,
   getConfigPath,
   parsePluginPackageJson,
+  pluginNameFromPackage,
   TOOLS_FILENAME,
   toErrorMessage,
 } from '@opentabs-dev/shared';
@@ -1126,7 +1127,19 @@ const runBuild = async (projectDir: string): Promise<void> => {
   const distDir = join(projectDir, 'dist');
   mkdirSync(distDir, { recursive: true });
 
-  await bundleIIFE(sourceEntry, distDir, plugin.name);
+  // Derive the canonical adapter key from the npm package name — this must
+  // match what the MCP server derives via pluginNameFromPackage() so the
+  // extension can look up the right adapter in globalThis.__openTabs.adapters.
+  const derivedName = pluginNameFromPackage(pkgJson.name);
+  if (plugin.name !== derivedName) {
+    console.warn(
+      pc.yellow(
+        `Warning: plugin class name "${plugin.name}" does not match the name derived from package.json ("${derivedName}"). The adapter will be registered as "${derivedName}". Update the plugin class name to avoid confusion.`,
+      ),
+    );
+  }
+
+  await bundleIIFE(sourceEntry, distDir, derivedName);
   // Read the bundled IIFE. esbuild appends a //# sourceMappingURL= comment at
   // the end when sourcemap:'linked' is used. Strip it so we can move it to the
   // very end of the file (after hashAndFreeze), keeping the source map reference
@@ -1155,7 +1168,7 @@ const runBuild = async (projectDir: string): Promise<void> => {
   // finds it at the end of the file, as required by the source map spec.
   // The '__adapterHash' property name must match ADAPTER_HASH_PROP in
   // platform/browser-extension/src/constants.ts.
-  const safeName = jsStringLiteral(plugin.name);
+  const safeName = jsStringLiteral(derivedName);
   const safeHash = jsStringLiteral(adapterHash);
   const hashAndFreeze = `(function(){var o=(globalThis).__openTabs;if(o&&o.adapters&&o.adapters[${safeName}]){var a=o.adapters[${safeName}];a.__adapterHash=${safeHash};if(a.tools&&Array.isArray(a.tools)){for(var i=0;i<a.tools.length;i++){Object.freeze(a.tools[i]);}Object.freeze(a.tools);}Object.freeze(a);Object.defineProperty(o.adapters,${safeName},{value:a,writable:false,configurable:false,enumerable:true});Object.defineProperty(o,"adapters",{value:o.adapters,writable:false,configurable:false});}})();`;
   await writeFile(iifePath, iifeContent + hashAndFreeze + sourceMappingUrlSuffix, 'utf-8');

--- a/platform/shared/src/constants.ts
+++ b/platform/shared/src/constants.ts
@@ -108,6 +108,37 @@ export const normalizePluginName = (name: string): string => {
   return candidates[0] ?? `@opentabs-dev/${PLUGIN_PREFIX}${name}`;
 };
 
+/**
+ * Derive the canonical plugin ID from an npm package name.
+ *
+ * The official `@opentabs-dev` scope is stripped (treated as unscoped). All
+ * other scopes are prepended with a hyphen separator. The `opentabs-plugin-`
+ * prefix is removed from the package name in all cases.
+ *
+ * Examples:
+ *   "opentabs-plugin-slack"                    → "slack"
+ *   "@opentabs-dev/opentabs-plugin-e2e-test"   → "e2e-test"
+ *   "@myorg/opentabs-plugin-jira"              → "myorg-jira"
+ */
+export const pluginNameFromPackage = (pkgName: string): string => {
+  const prefixPattern = new RegExp(`^${PLUGIN_PREFIX}`);
+  if (pkgName.startsWith('@')) {
+    const parts = pkgName.split('/');
+    const scopePart = parts[0] ?? '';
+    const namePart = parts[1] ?? '';
+    const pluginSuffix = namePart.replace(prefixPattern, '');
+
+    // Official scope is invisible — treat like an unscoped package
+    if (scopePart === '@opentabs-dev') {
+      return pluginSuffix;
+    }
+
+    const scope = scopePart.slice(1);
+    return `${scope}-${pluginSuffix}`;
+  }
+  return pkgName.replace(prefixPattern, '');
+};
+
 // ---------------------------------------------------------------------------
 // Cryptography
 // ---------------------------------------------------------------------------

--- a/platform/shared/src/index.ts
+++ b/platform/shared/src/index.ts
@@ -52,6 +52,7 @@ export {
   normalizePluginName,
   PLATFORM_PACKAGES,
   PLUGIN_PREFIX,
+  pluginNameFromPackage,
   resolvePluginPackageCandidates,
   TOOLS_FILENAME,
 } from './constants.js';


### PR DESCRIPTION
Closes #42

## Summary

- Moves `pluginNameFromPackage()` from `platform/mcp-server/src/loader.ts` into `@opentabs-dev/shared` (`constants.ts`), alongside `PLUGIN_PREFIX` which it depends on, and exports it from the shared barrel
- Updates `mcp-server/loader.ts` to import from `@opentabs-dev/shared` (removes the local definition)
- Updates `plugin-tools/build.ts` to derive the adapter IIFE key from `pkgJson.name` via `pluginNameFromPackage()` instead of `plugin.name`, fixing the key mismatch for third-party scoped packages
- Emits a build-time warning when `plugin.name` doesn't match the derived name, so plugin authors catch the inconsistency immediately

## Test plan

- [ ] Build a third-party scoped plugin (e.g. `@myorg/opentabs-plugin-foo` with `name = 'foo'`) — adapter should now register under `adapters["myorg-foo"]` and injection should succeed
- [ ] Official `@opentabs-dev` plugins unaffected — `pluginNameFromPackage` strips the scope, producing the same bare name as before
- [ ] Build warning fires when `plugin.name` doesn't match the derived name
- [ ] `npm run build`, `type-check`, `lint`, `knip`, and `test` all pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated plugin naming logic into a shared utility for consistency across the platform.
  * Added validation warnings when plugin names differ from their derived package names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->