### PR TITLE
feat(ynab): add category management tools

### DIFF
--- a/plugins/ynab/src/index.ts
+++ b/plugins/ynab/src/index.ts
@@ -1,6 +1,10 @@
 import type { ToolDefinition } from '@opentabs-dev/plugin-sdk';
 import { OpenTabsPlugin } from '@opentabs-dev/plugin-sdk';
+import { createCategory } from './tools/create-category.js';
+import { createCategoryGroup } from './tools/create-category-group.js';
 import { createTransaction } from './tools/create-transaction.js';
+import { deleteCategory } from './tools/delete-category.js';
+import { deleteCategoryGroup } from './tools/delete-category-group.js';
 import { deleteTransaction } from './tools/delete-transaction.js';
 import { getAccount } from './tools/get-account.js';
 import { getCurrentUser } from './tools/get-current-user.js';
@@ -14,6 +18,8 @@ import { listPayees } from './tools/list-payees.js';
 import { listScheduledTransactions } from './tools/list-scheduled-transactions.js';
 import { listTransactions } from './tools/list-transactions.js';
 import { moveCategoryBudget } from './tools/move-category-budget.js';
+import { snoozeCategoryGoal } from './tools/snooze-category-goal.js';
+import { updateCategory } from './tools/update-category.js';
 import { updateCategoryBudget } from './tools/update-category-budget.js';
 import { updateTransaction } from './tools/update-transaction.js';
 import { isAuthenticated, waitForAuth } from './ynab-api.js';
@@ -34,8 +40,14 @@ class YnabPlugin extends OpenTabsPlugin {
     getAccount,
     // Categories
     listCategories,
+    createCategory,
+    updateCategory,
+    deleteCategory,
+    createCategoryGroup,
+    deleteCategoryGroup,
     updateCategoryBudget,
     moveCategoryBudget,
+    snoozeCategoryGoal,
     // Payees
     listPayees,
     // Transactions

--- a/plugins/ynab/src/tools/create-category-group.ts
+++ b/plugins/ynab/src/tools/create-category-group.ts
@@ -1,0 +1,42 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
+import type { BudgetEntities, RawCategoryGroup } from './schemas.js';
+import { categoryGroupSchema, mapCategoryGroup, nextTopSortableIndex } from './schemas.js';
+
+export const createCategoryGroup = defineTool({
+  name: 'create_category_group',
+  displayName: 'Create Category Group',
+  description: 'Create a new category group in the active YNAB plan.',
+  summary: 'Create a category group',
+  icon: 'folder-plus',
+  group: 'Categories',
+  input: z.object({
+    name: z.string().min(1).describe('Name of the new category group'),
+  }),
+  output: z.object({
+    group: categoryGroupSchema,
+  }),
+  handle: async params => {
+    const planId = getPlanId();
+    const groupId = crypto.randomUUID();
+
+    const budget = await syncBudget<BudgetEntities>(planId);
+    const serverKnowledge = budget.current_server_knowledge ?? 0;
+
+    const groupEntry: RawCategoryGroup = {
+      id: groupId,
+      is_tombstone: false,
+      internal_name: '',
+      deletable: true,
+      sortable_index: nextTopSortableIndex(budget.changed_entities?.be_master_categories ?? []),
+      name: params.name,
+      note: '',
+      is_hidden: false,
+    };
+
+    await syncWrite<BudgetEntities>(planId, { be_master_categories: [groupEntry] }, serverKnowledge);
+
+    return { group: mapCategoryGroup(groupEntry) };
+  },
+});

--- a/plugins/ynab/src/tools/create-category.ts
+++ b/plugins/ynab/src/tools/create-category.ts
@@ -1,8 +1,9 @@
-import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
 import type { BudgetEntities, RawCategory, RawMonthlySubcategoryBudget } from './schemas.js';
 import {
+  assertCategoryGroupDeletable,
   buildGoalFields,
   CATEGORY_TYPE_DEFAULT,
   categorySchema,
@@ -19,7 +20,7 @@ export const createCategory = defineTool({
   name: 'create_category',
   displayName: 'Create Category',
   description:
-    'Create a new category in an existing category group. Optionally set an initial goal: "set_aside" (set aside X per cadence), "refill" (refill the balance up to X per cadence), "target_balance" (have a balance of X), "target_by_date" (have a balance of X by a specific date), or "debt" (recurring debt payment). NEED-style goals (set_aside, refill) accept weekly/monthly/yearly cadence.',
+    'Create a new category in an existing category group. Optionally set an initial goal: "set_aside" (set aside X per cadence), "refill" (refill the balance up to X per cadence), "target_balance" (have a balance of X), or "target_by_date" (have a balance of X by a specific date). NEED-style goals (set_aside, refill) accept weekly/monthly/yearly cadence. Debt goals are not supported for new categories — they only apply to existing debt-account categories.',
   summary: 'Create a new budget category',
   icon: 'plus',
   group: 'Categories',
@@ -33,13 +34,17 @@ export const createCategory = defineTool({
     category: categorySchema,
   }),
   handle: async params => {
+    if (params.goal?.type === 'debt') {
+      throw ToolError.validation('Debt goals can only be set on debt-account categories.');
+    }
+
     const planId = getPlanId();
     const categoryId = crypto.randomUUID();
 
     const budget = await syncBudget<BudgetEntities>(planId);
     const serverKnowledge = budget.current_server_knowledge ?? 0;
 
-    findCategoryGroup(budget.changed_entities, params.group_id);
+    assertCategoryGroupDeletable(findCategoryGroup(budget.changed_entities, params.group_id));
 
     const childCategories = (budget.changed_entities?.be_subcategories ?? []).filter(
       c => c.entities_master_category_id === params.group_id,

--- a/plugins/ynab/src/tools/create-category.ts
+++ b/plugins/ynab/src/tools/create-category.ts
@@ -1,0 +1,85 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
+import type { BudgetEntities, RawCategory, RawMonthlySubcategoryBudget } from './schemas.js';
+import {
+  buildGoalFields,
+  CATEGORY_TYPE_DEFAULT,
+  categorySchema,
+  currentMonthKey,
+  findCategoryGroup,
+  formatMonthlyBudgetId,
+  formatSubcategoryBudgetId,
+  goalSpecSchema,
+  mapCategory,
+  nextTopSortableIndex,
+} from './schemas.js';
+
+export const createCategory = defineTool({
+  name: 'create_category',
+  displayName: 'Create Category',
+  description:
+    'Create a new category in an existing category group. Optionally set an initial goal: "set_aside" (set aside X per cadence), "refill" (refill the balance up to X per cadence), "target_balance" (have a balance of X), "target_by_date" (have a balance of X by a specific date), or "debt" (recurring debt payment). NEED-style goals (set_aside, refill) accept weekly/monthly/yearly cadence.',
+  summary: 'Create a new budget category',
+  icon: 'plus',
+  group: 'Categories',
+  input: z.object({
+    group_id: z.string().min(1).describe('Category group ID to create the category in'),
+    name: z.string().min(1).describe('Name of the new category'),
+    goal: goalSpecSchema.optional().describe('Optional initial goal for the category'),
+    note: z.string().optional().describe('Optional note for the category'),
+  }),
+  output: z.object({
+    category: categorySchema,
+  }),
+  handle: async params => {
+    const planId = getPlanId();
+    const categoryId = crypto.randomUUID();
+
+    const budget = await syncBudget<BudgetEntities>(planId);
+    const serverKnowledge = budget.current_server_knowledge ?? 0;
+
+    findCategoryGroup(budget.changed_entities, params.group_id);
+
+    const childCategories = (budget.changed_entities?.be_subcategories ?? []).filter(
+      c => c.entities_master_category_id === params.group_id,
+    );
+    const monthKey = currentMonthKey();
+    const categoryEntry: RawCategory = {
+      id: categoryId,
+      is_tombstone: false,
+      entities_master_category_id: params.group_id,
+      entities_account_id: null,
+      internal_name: null,
+      sortable_index: nextTopSortableIndex(childCategories, 5),
+      name: params.name,
+      type: CATEGORY_TYPE_DEFAULT,
+      note: params.note ?? null,
+      monthly_funding: 0,
+      is_hidden: false,
+      pinned_index: null,
+      pinned_goal_index: null,
+      ...buildGoalFields(params.goal),
+    };
+
+    // YNAB's UI also creates a current-month budget row alongside the category.
+    const budgetEntry: RawMonthlySubcategoryBudget = {
+      id: formatSubcategoryBudgetId(monthKey, categoryId),
+      is_tombstone: false,
+      entities_monthly_budget_id: formatMonthlyBudgetId(monthKey, planId),
+      entities_subcategory_id: categoryId,
+      budgeted: 0,
+    };
+
+    await syncWrite<BudgetEntities>(
+      planId,
+      {
+        be_subcategories: [categoryEntry],
+        be_monthly_subcategory_budgets: [budgetEntry],
+      },
+      serverKnowledge,
+    );
+
+    return { category: mapCategory(categoryEntry) };
+  },
+});

--- a/plugins/ynab/src/tools/delete-category-group.ts
+++ b/plugins/ynab/src/tools/delete-category-group.ts
@@ -1,8 +1,8 @@
-import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
+import { defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
 import type { BudgetEntities } from './schemas.js';
-import { findCategoryGroup, notTombstone } from './schemas.js';
+import { assertCategoryGroupDeletable, findCategoryGroup, notTombstone } from './schemas.js';
 
 export const deleteCategoryGroup = defineTool({
   name: 'delete_category_group',
@@ -26,12 +26,7 @@ export const deleteCategoryGroup = defineTool({
     const serverKnowledge = budget.current_server_knowledge ?? 0;
 
     const group = findCategoryGroup(budget.changed_entities, params.group_id);
-    // Default-deny: only allow deletion when YNAB explicitly marks the group as deletable.
-    // Internal groups (Credit Card Payments, Hidden Categories, Internal Master Category)
-    // either have deletable=false or omit the field entirely.
-    if (group.deletable !== true) {
-      throw ToolError.validation(`Category group "${group.name}" is not deletable.`);
-    }
+    assertCategoryGroupDeletable(group);
 
     const childCategories = (budget.changed_entities?.be_subcategories ?? []).filter(
       c => c.entities_master_category_id === params.group_id && notTombstone(c),

--- a/plugins/ynab/src/tools/delete-category-group.ts
+++ b/plugins/ynab/src/tools/delete-category-group.ts
@@ -1,0 +1,51 @@
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
+import type { BudgetEntities } from './schemas.js';
+import { findCategoryGroup, notTombstone } from './schemas.js';
+
+export const deleteCategoryGroup = defineTool({
+  name: 'delete_category_group',
+  displayName: 'Delete Category Group',
+  description:
+    'Delete a category group and all of its child categories from the active YNAB plan. This is a soft delete (tombstone). Internal/non-deletable groups (Credit Card Payments, Hidden Categories, Internal Master Category) cannot be deleted.',
+  summary: 'Delete a category group and its children',
+  icon: 'folder-x',
+  group: 'Categories',
+  input: z.object({
+    group_id: z.string().min(1).describe('Category group ID to delete'),
+  }),
+  output: z.object({
+    success: z.boolean(),
+    deleted_category_count: z.number().describe('Number of child categories that were also tombstoned'),
+  }),
+  handle: async params => {
+    const planId = getPlanId();
+
+    const budget = await syncBudget<BudgetEntities>(planId);
+    const serverKnowledge = budget.current_server_knowledge ?? 0;
+
+    const group = findCategoryGroup(budget.changed_entities, params.group_id);
+    // Default-deny: only allow deletion when YNAB explicitly marks the group as deletable.
+    // Internal groups (Credit Card Payments, Hidden Categories, Internal Master Category)
+    // either have deletable=false or omit the field entirely.
+    if (group.deletable !== true) {
+      throw ToolError.validation(`Category group "${group.name}" is not deletable.`);
+    }
+
+    const childCategories = (budget.changed_entities?.be_subcategories ?? []).filter(
+      c => c.entities_master_category_id === params.group_id && notTombstone(c),
+    );
+
+    await syncWrite<BudgetEntities>(
+      planId,
+      {
+        be_master_categories: [{ ...group, is_tombstone: true }],
+        be_subcategories: childCategories.map(c => ({ ...c, is_tombstone: true })),
+      },
+      serverKnowledge,
+    );
+
+    return { success: true, deleted_category_count: childCategories.length };
+  },
+});

--- a/plugins/ynab/src/tools/delete-category.ts
+++ b/plugins/ynab/src/tools/delete-category.ts
@@ -1,0 +1,36 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
+import type { BudgetEntities } from './schemas.js';
+import { findCategory } from './schemas.js';
+
+export const deleteCategory = defineTool({
+  name: 'delete_category',
+  displayName: 'Delete Category',
+  description:
+    'Delete a category from the active YNAB plan. This is a soft delete (tombstone). Existing transactions assigned to this category remain in place but the category will no longer appear in budget views.',
+  summary: 'Delete a category',
+  icon: 'trash-2',
+  group: 'Categories',
+  input: z.object({
+    category_id: z.string().min(1).describe('Category ID to delete'),
+  }),
+  output: z.object({
+    success: z.boolean(),
+  }),
+  handle: async params => {
+    const planId = getPlanId();
+
+    const budget = await syncBudget<BudgetEntities>(planId);
+    const serverKnowledge = budget.current_server_knowledge ?? 0;
+    const existing = findCategory(budget.changed_entities, params.category_id);
+
+    await syncWrite<BudgetEntities>(
+      planId,
+      { be_subcategories: [{ ...existing, is_tombstone: true }] },
+      serverKnowledge,
+    );
+
+    return { success: true };
+  },
+});

--- a/plugins/ynab/src/tools/delete-category.ts
+++ b/plugins/ynab/src/tools/delete-category.ts
@@ -2,7 +2,7 @@ import { defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
 import type { BudgetEntities } from './schemas.js';
-import { findCategory } from './schemas.js';
+import { assertCategoryDeletable, findCategory } from './schemas.js';
 
 export const deleteCategory = defineTool({
   name: 'delete_category',
@@ -24,6 +24,7 @@ export const deleteCategory = defineTool({
     const budget = await syncBudget<BudgetEntities>(planId);
     const serverKnowledge = budget.current_server_knowledge ?? 0;
     const existing = findCategory(budget.changed_entities, params.category_id);
+    assertCategoryDeletable(existing);
 
     await syncWrite<BudgetEntities>(
       planId,

--- a/plugins/ynab/src/tools/move-category-budget.ts
+++ b/plugins/ynab/src/tools/move-category-budget.ts
@@ -1,11 +1,12 @@
-import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
+import { defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { getPlanId, getUserId, syncBudget, syncWrite } from '../ynab-api.js';
-import type { BudgetEntities, RawCategory, RawMonthlySubcategoryBudget } from './schemas.js';
+import type { BudgetEntities, RawMonthlySubcategoryBudget } from './schemas.js';
 import {
   buildSubcategoryBudgetMap,
   buildSubcategoryCalcMap,
   categorySchema,
+  findCategory,
   formatMonthlyBudgetId,
   formatSubcategoryBudgetId,
   MONEY_MOVEMENT_SOURCE,
@@ -53,19 +54,15 @@ export const moveCategoryBudget = defineTool({
 
     const budget = await syncBudget<BudgetEntities>(planId);
     const serverKnowledge = budget.current_server_knowledge ?? 0;
-    const subcategories = budget.changed_entities?.be_subcategories ?? [];
     const existingBudgets = budget.changed_entities?.be_monthly_subcategory_budgets ?? [];
 
-    const findCategory = (id: string): RawCategory & { id: string } => {
-      const c = subcategories.find(s => s.id === id && notTombstone(s));
-      if (!c?.id) throw ToolError.notFound(`Category not found: ${id}`);
-      return { ...c, id: c.id };
-    };
-    const fromCategory = params.from_category_id ? findCategory(params.from_category_id) : null;
-    const toCategory = params.to_category_id ? findCategory(params.to_category_id) : null;
+    const fromCategoryId = params.from_category_id;
+    const toCategoryId = params.to_category_id;
+    const fromCategory = fromCategoryId ? findCategory(budget.changed_entities, fromCategoryId) : null;
+    const toCategory = toCategoryId ? findCategory(budget.changed_entities, toCategoryId) : null;
 
-    const fromBudgetId = fromCategory ? formatSubcategoryBudgetId(monthKey, fromCategory.id) : null;
-    const toBudgetId = toCategory ? formatSubcategoryBudgetId(monthKey, toCategory.id) : null;
+    const fromBudgetId = fromCategoryId ? formatSubcategoryBudgetId(monthKey, fromCategoryId) : null;
+    const toBudgetId = toCategoryId ? formatSubcategoryBudgetId(monthKey, toCategoryId) : null;
 
     const buildEntry = (categoryId: string, budgetId: string, signedDelta: number): RawMonthlySubcategoryBudget => {
       const current = existingBudgets.find(b => b.id === budgetId && notTombstone(b))?.budgeted ?? 0;
@@ -79,10 +76,10 @@ export const moveCategoryBudget = defineTool({
     };
 
     const budgetEntries: RawMonthlySubcategoryBudget[] = [];
-    if (fromCategory && fromBudgetId) budgetEntries.push(buildEntry(fromCategory.id, fromBudgetId, -milliunits));
-    if (toCategory && toBudgetId) budgetEntries.push(buildEntry(toCategory.id, toBudgetId, milliunits));
+    if (fromCategoryId && fromBudgetId) budgetEntries.push(buildEntry(fromCategoryId, fromBudgetId, -milliunits));
+    if (toCategoryId && toBudgetId) budgetEntries.push(buildEntry(toCategoryId, toBudgetId, milliunits));
 
-    const source = fromCategory && toCategory ? MONEY_MOVEMENT_SOURCE.MOVEMENT : MONEY_MOVEMENT_SOURCE.ASSIGN;
+    const source = fromCategoryId && toCategoryId ? MONEY_MOVEMENT_SOURCE.MOVEMENT : MONEY_MOVEMENT_SOURCE.ASSIGN;
 
     const result = await syncWrite<BudgetEntities>(
       planId,

--- a/plugins/ynab/src/tools/schemas.ts
+++ b/plugins/ynab/src/tools/schemas.ts
@@ -1,4 +1,4 @@
-import { log } from '@opentabs-dev/plugin-sdk';
+import { log, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 
 // --- Currency formatting ---
@@ -14,6 +14,30 @@ export const toMilliunits = (amount: number): number => Math.round(amount * 1000
 export const notTombstone = <T extends { is_tombstone?: boolean }>(
   x: T,
 ): x is T & { is_tombstone?: false | undefined } => !x.is_tombstone;
+
+// --- Common entity lookups ---
+
+export const findCategory = (entities: BudgetEntities | undefined, id: string) => {
+  const c = (entities?.be_subcategories ?? []).find(s => s.id === id && notTombstone(s));
+  if (!c) throw ToolError.notFound(`Category not found: ${id}`);
+  return c;
+};
+
+export const findCategoryGroup = (entities: BudgetEntities | undefined, id: string) => {
+  const g = (entities?.be_master_categories ?? []).find(m => m.id === id && notTombstone(m));
+  if (!g) throw ToolError.notFound(`Category group not found: ${id}`);
+  return g;
+};
+
+// Returns a sortable_index strictly less than every existing index in `rows`,
+// so a freshly created entity sorts to the top of its container.
+export const nextTopSortableIndex = (rows: { sortable_index?: number }[], step = 10): number => {
+  let min = 0;
+  for (const r of rows) {
+    if (typeof r.sortable_index === 'number' && r.sortable_index < min) min = r.sortable_index;
+  }
+  return min - step;
+};
 
 // --- Shared output schemas ---
 
@@ -185,20 +209,38 @@ export interface RawCategoryGroup {
   id?: string;
   name?: string;
   is_hidden?: boolean | null;
+  internal_name?: string | null;
+  deletable?: boolean;
+  sortable_index?: number;
+  note?: string | null;
   is_tombstone?: boolean;
 }
 
 export interface RawCategory {
   id?: string;
   entities_master_category_id?: string;
+  entities_account_id?: string | null;
+  internal_name?: string | null;
+  sortable_index?: number;
   name?: string;
+  type?: string;
   is_hidden?: boolean | null;
   budgeted?: number;
   activity?: number;
   balance?: number;
   goal_type?: string | null;
   goal_target?: number | null;
+  goal_target_amount?: number | null;
+  goal_target_date?: string | null;
+  goal_created_on?: string | null;
+  goal_needs_whole_amount?: boolean | null;
+  goal_cadence?: number | null;
+  goal_cadence_frequency?: number | null;
+  goal_day?: number | null;
+  monthly_funding?: number | null;
   goal_percentage_complete?: number | null;
+  pinned_index?: number | null;
+  pinned_goal_index?: number | null;
   is_tombstone?: boolean;
   note?: string | null;
 }
@@ -270,6 +312,7 @@ export interface RawMonthlySubcategoryBudget {
   entities_monthly_budget_id?: string;
   entities_subcategory_id?: string;
   budgeted?: number;
+  goal_snoozed_at?: string | null;
   is_tombstone?: boolean;
 }
 
@@ -278,7 +321,8 @@ export interface RawMonthlySubcategoryBudgetCalc {
   balance?: number;
   cash_outflows?: number;
   credit_outflows?: number;
-  goal_target?: number | null;
+  // goal_target is intentionally not surfaced — it's the dynamically-computed
+  // "remaining to fund this month" which is misleading vs the configured target.
   goal_percentage_complete?: number | null;
 }
 
@@ -308,6 +352,23 @@ export const MONEY_MOVEMENT_SOURCE = {
   /** Category-to-category transfer. */
   MOVEMENT: 'manual_movement',
 } as const;
+
+export const GOAL_TYPE = {
+  /** "Set aside" or "Refill" — `goal_needs_whole_amount` differentiates. */
+  NEED: 'NEED',
+  /** "Have a balance of" — no date, no cadence. */
+  TARGET_BALANCE: 'TB',
+  /** "Have a balance of by date" — one-shot with `goal_target_date`. */
+  TARGET_BY_DATE: 'TBD',
+  /** Debt payment goals on debt-account categories. */
+  DEBT: 'DEBT',
+  /** Legacy "Monthly Funding". The modern UI no longer creates these but they
+      still exist on older categories and the API still honors them. */
+  MONTHLY_FUNDING: 'MF',
+} as const;
+
+/** YNAB's default category type for non-credit-card categories. */
+export const CATEGORY_TYPE_DEFAULT = 'DFT';
 
 // Entity ID prefixes used by the YNAB sync API.
 const SUBCATEGORY_BUDGET_PREFIX = 'mcb';
@@ -343,6 +404,170 @@ export const FLAG_MAP: Record<FlagColor, string> = {
   green: 'Green',
   blue: 'Blue',
   purple: 'Purple',
+};
+
+// --- Category goal types ---
+//
+// YNAB's modern UI exposes these goal kinds, all writing to be_subcategories:
+//   "Set aside"           → NEED with goal_needs_whole_amount=true  (recharges per cadence)
+//   "Refill"              → NEED with goal_needs_whole_amount=false (refills up to target)
+//   "Have a balance of"   → TB  (no date, no cadence)
+//   "Have a balance by date" → TBD (target_date, no cadence)
+// Legacy categories may carry MF (Monthly Funding); the modern UI no longer
+// creates new MF goals but the API still honors existing ones.
+//
+// Cadence wire encoding (verified by capturing the YNAB UI):
+//   goal_cadence: 1 = monthly, 2 = weekly, 13 = yearly
+//   goal_cadence_frequency: "every N" multiplier (default 1)
+//   goal_day: day-of-week (0=Sunday, 6=Saturday) for weekly,
+//             day-of-month (1-31) for monthly, unused for yearly
+//   goal_target_date: first occurrence date — required for yearly,
+//                     optional anchor for monthly with custom intervals
+
+export type GoalCadence = 'weekly' | 'monthly' | 'yearly';
+
+const cadenceWireValue: Record<GoalCadence, number> = {
+  weekly: 2,
+  monthly: 1,
+  yearly: 13,
+};
+
+const needGoalShape = {
+  target: z.number().positive().describe('Goal amount in currency units (e.g. 50 for $50)'),
+  cadence: z
+    .enum(['weekly', 'monthly', 'yearly'])
+    .optional()
+    .describe('How often the goal recurs. Defaults to monthly.'),
+  every: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Multiplier on cadence (e.g. cadence=monthly + every=5 means every 5 months). Defaults to 1.'),
+  day: z
+    .number()
+    .int()
+    .min(0)
+    .max(31)
+    .optional()
+    .describe('Day-of-week (0=Sunday, 6=Saturday) for weekly cadence, or day-of-month (1-31) for monthly cadence.'),
+  start_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD')
+    .optional()
+    .describe('First occurrence date (YYYY-MM-DD). Required for yearly cadence; optional for others.'),
+} as const;
+
+// Yearly NEED goals require start_date (the first occurrence) since YNAB
+// can't infer the recurrence anchor without it.
+const yearlyNeedRefine = (data: { cadence?: GoalCadence; start_date?: string }, ctx: z.RefinementCtx): void => {
+  if (data.cadence === 'yearly' && !data.start_date) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'start_date is required when cadence is "yearly"',
+      path: ['start_date'],
+    });
+  }
+};
+
+export const goalSpecSchema = z.discriminatedUnion('type', [
+  z
+    .object({ type: z.literal('set_aside'), ...needGoalShape })
+    .strict()
+    .superRefine(yearlyNeedRefine),
+  z
+    .object({ type: z.literal('refill'), ...needGoalShape })
+    .strict()
+    .superRefine(yearlyNeedRefine),
+  z
+    .object({
+      type: z.literal('target_balance'),
+      target: z.number().positive().describe('Balance to maintain in currency units'),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('target_by_date'),
+      target: z.number().positive().describe('Target balance to have by the given date in currency units'),
+      date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD')
+        .describe('Target date YYYY-MM-DD'),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('debt'),
+      target: z.number().positive().describe('Monthly payment amount in currency units'),
+      day: z
+        .number()
+        .int()
+        .min(1)
+        .max(31)
+        .optional()
+        .describe('Day of month the payment is due (1-31). Defaults to 1.'),
+    })
+    .strict(),
+  z.object({ type: z.literal('none') }).strict(),
+]);
+
+export type GoalSpec = z.infer<typeof goalSpecSchema>;
+
+const NO_GOAL_FIELDS = {
+  goal_type: null,
+  goal_created_on: null,
+  goal_needs_whole_amount: null,
+  goal_target_amount: 0,
+  goal_target_date: null,
+  goal_cadence: null,
+  goal_cadence_frequency: null,
+  goal_day: null,
+} as const;
+
+// Translate a high-level goal spec into the wire fields YNAB stores on a
+// be_subcategories row. Returns the goal-related fields only.
+export const buildGoalFields = (goal: GoalSpec | undefined): Partial<RawCategory> => {
+  if (!goal || goal.type === 'none') return { ...NO_GOAL_FIELDS };
+
+  // goal_created_on is the first day of the month the goal was created.
+  const now = new Date();
+  const createdOn = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+  const base = { ...NO_GOAL_FIELDS, goal_created_on: createdOn };
+
+  switch (goal.type) {
+    case 'set_aside':
+    case 'refill': {
+      const cadence = goal.cadence ?? 'monthly';
+      return {
+        ...base,
+        goal_type: GOAL_TYPE.NEED,
+        goal_needs_whole_amount: goal.type === 'set_aside',
+        goal_target_amount: toMilliunits(goal.target),
+        goal_cadence: cadenceWireValue[cadence],
+        goal_cadence_frequency: goal.every ?? 1,
+        goal_day: cadence === 'yearly' ? null : (goal.day ?? null),
+        goal_target_date: goal.start_date ?? null,
+      };
+    }
+    case 'target_balance':
+      return { ...base, goal_type: GOAL_TYPE.TARGET_BALANCE, goal_target_amount: toMilliunits(goal.target) };
+    case 'target_by_date':
+      return {
+        ...base,
+        goal_type: GOAL_TYPE.TARGET_BY_DATE,
+        goal_target_amount: toMilliunits(goal.target),
+        goal_target_date: goal.date,
+      };
+    case 'debt':
+      return {
+        ...base,
+        goal_type: GOAL_TYPE.DEBT,
+        goal_target_amount: toMilliunits(goal.target),
+        goal_cadence: cadenceWireValue.monthly,
+        goal_cadence_frequency: 1,
+        goal_day: goal.day ?? 1,
+      };
+  }
 };
 
 // --- Shared budget data types ---
@@ -461,7 +686,6 @@ export const mapCategoryForMonth = (
     budgeted: budget?.budgeted ?? c.budgeted,
     activity: (calc?.cash_outflows ?? 0) + (calc?.credit_outflows ?? 0),
     balance: calc?.balance ?? c.balance,
-    goal_target: calc?.goal_target ?? c.goal_target,
     goal_percentage_complete: calc?.goal_percentage_complete ?? c.goal_percentage_complete,
   });
 };
@@ -580,7 +804,15 @@ export const mapCategory = (c: RawCategory) => ({
   activity_milliunits: c.activity ?? 0,
   balance_milliunits: c.balance ?? 0,
   goal_type: c.goal_type ?? '',
-  goal_target: formatMilliunits(c.goal_target ?? 0),
+  // The "goal target" the user configured is stored on the category itself:
+  // - MF (legacy Monthly Funding): the static target lives in `monthly_funding`
+  // - All modern goal types (NEED, TB, TBD, DEBT): use `goal_target_amount`
+  // The calc's `goal_target` is YNAB's dynamically-computed "needed this month",
+  // which for refill goals returns max(0, target - current_balance) — surprising
+  // and not what users mean when they ask for the goal target.
+  goal_target: formatMilliunits(
+    (c.goal_type === GOAL_TYPE.MONTHLY_FUNDING ? c.monthly_funding : c.goal_target_amount) ?? 0,
+  ),
   goal_percentage_complete: c.goal_percentage_complete ?? 0,
 });
 

--- a/plugins/ynab/src/tools/schemas.ts
+++ b/plugins/ynab/src/tools/schemas.ts
@@ -29,6 +29,24 @@ export const findCategoryGroup = (entities: BudgetEntities | undefined, id: stri
   return g;
 };
 
+// Default-deny: only allow writes when YNAB explicitly marks the group as deletable.
+// Internal groups (Credit Card Payments, Hidden Categories, Internal Master Category)
+// either have deletable=false or omit the field entirely.
+export const assertCategoryGroupDeletable = (group: RawCategoryGroup): void => {
+  if (group.deletable !== true) {
+    throw ToolError.validation(`Category group "${group.name}" is not deletable.`);
+  }
+};
+
+// Only user-created default categories can be deleted. Credit card payment
+// categories (type DBT) and account-linked categories (entities_account_id set)
+// are system-managed and must not be tombstoned.
+export const assertCategoryDeletable = (category: RawCategory): void => {
+  if (category.entities_account_id != null || category.type !== CATEGORY_TYPE_DEFAULT) {
+    throw ToolError.validation(`Category "${category.name}" is system-managed and cannot be deleted.`);
+  }
+};
+
 // Returns a sortable_index strictly less than every existing index in `rows`,
 // so a freshly created entity sorts to the top of its container.
 export const nextTopSortableIndex = (rows: { sortable_index?: number }[], step = 10): number => {
@@ -432,6 +450,16 @@ const cadenceWireValue: Record<GoalCadence, number> = {
   yearly: 13,
 };
 
+const isValidCalendarDate = (s: string): boolean => {
+  const parts = s.split('-').map(Number);
+  const year = parts[0] ?? 0;
+  const month = parts[1] ?? 0;
+  const day = parts[2] ?? 0;
+  if (month < 1 || month > 12) return false;
+  const maxDay = new Date(year, month, 0).getDate();
+  return day >= 1 && day <= maxDay;
+};
+
 const needGoalShape = {
   target: z.number().positive().describe('Goal amount in currency units (e.g. 50 for $50)'),
   cadence: z
@@ -454,6 +482,7 @@ const needGoalShape = {
   start_date: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD')
+    .refine(isValidCalendarDate, 'Date must be a valid calendar date')
     .optional()
     .describe('First occurrence date (YYYY-MM-DD). Required for yearly cadence; optional for others.'),
 } as const;
@@ -470,15 +499,41 @@ const yearlyNeedRefine = (data: { cadence?: GoalCadence; start_date?: string }, 
   }
 };
 
+const needCadenceDayRefine = (data: { cadence?: GoalCadence; day?: number }, ctx: z.RefinementCtx): void => {
+  if (data.day === undefined) return;
+  const cadence = data.cadence ?? 'monthly';
+  if (cadence === 'weekly' && (data.day < 0 || data.day > 6)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'For weekly cadence, day must be 0–6 (0=Sunday, 6=Saturday)',
+      path: ['day'],
+    });
+  } else if (cadence === 'monthly' && (data.day < 1 || data.day > 31)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'For monthly cadence, day must be 1–31',
+      path: ['day'],
+    });
+  } else if (cadence === 'yearly') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'For yearly cadence, use start_date to set the recurrence anchor instead of day',
+      path: ['day'],
+    });
+  }
+};
+
 export const goalSpecSchema = z.discriminatedUnion('type', [
   z
     .object({ type: z.literal('set_aside'), ...needGoalShape })
     .strict()
-    .superRefine(yearlyNeedRefine),
+    .superRefine(yearlyNeedRefine)
+    .superRefine(needCadenceDayRefine),
   z
     .object({ type: z.literal('refill'), ...needGoalShape })
     .strict()
-    .superRefine(yearlyNeedRefine),
+    .superRefine(yearlyNeedRefine)
+    .superRefine(needCadenceDayRefine),
   z
     .object({
       type: z.literal('target_balance'),
@@ -492,6 +547,7 @@ export const goalSpecSchema = z.discriminatedUnion('type', [
       date: z
         .string()
         .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD')
+        .refine(isValidCalendarDate, 'Date must be a valid calendar date')
         .describe('Target date YYYY-MM-DD'),
     })
     .strict(),
@@ -619,7 +675,9 @@ export const resolvePayee = (
 // --- Calculation map builders ---
 
 export const buildAccountCalcMap = (entities: BudgetEntities) =>
-  new Map((entities.be_account_calculations ?? []).map(c => [c.entities_account_id, c]));
+  new Map(
+    (entities.be_account_calculations ?? []).filter(c => c.entities_account_id).map(c => [c.entities_account_id, c]),
+  );
 
 // Entity ID format: "mb/YYYY-MM/<planId>" — key by YYYY-MM
 export const buildMonthlyBudgetCalcMap = (calcs: RawMonthlyBudgetCalc[]) => {

--- a/plugins/ynab/src/tools/snooze-category-goal.ts
+++ b/plugins/ynab/src/tools/snooze-category-goal.ts
@@ -1,0 +1,63 @@
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
+import type { BudgetEntities, RawMonthlySubcategoryBudget } from './schemas.js';
+import { findCategory, formatMonthlyBudgetId, formatSubcategoryBudgetId, notTombstone, toMonthKey } from './schemas.js';
+
+export const snoozeCategoryGoal = defineTool({
+  name: 'snooze_category_goal',
+  displayName: 'Snooze Category Goal',
+  description:
+    'Snooze a category goal for a specific month so it does not appear as needing funding for that month. Pass snooze=false to un-snooze.',
+  summary: 'Snooze a category goal for a month',
+  icon: 'bell-off',
+  group: 'Categories',
+  input: z.object({
+    category_id: z.string().min(1).describe('Category ID whose goal to snooze'),
+    month: z
+      .string()
+      .regex(/^\d{4}-\d{2}(-\d{2})?$/, 'Month must be YYYY-MM or YYYY-MM-DD')
+      .describe('Month in YYYY-MM format (e.g. 2026-04)'),
+    snooze: z.boolean().optional().describe('true to snooze (default), false to un-snooze'),
+  }),
+  output: z.object({
+    success: z.boolean(),
+    snoozed_at: z.string().nullable().describe('ISO timestamp the goal was snoozed at, or null if un-snoozed'),
+  }),
+  handle: async params => {
+    const planId = getPlanId();
+    const monthKey = toMonthKey(params.month);
+    const budgetId = formatSubcategoryBudgetId(monthKey, params.category_id);
+    const monthlyBudgetId = formatMonthlyBudgetId(monthKey, planId);
+    const shouldSnooze = params.snooze ?? true;
+
+    const budget = await syncBudget<BudgetEntities>(planId);
+    const serverKnowledge = budget.current_server_knowledge ?? 0;
+
+    const category = findCategory(budget.changed_entities, params.category_id);
+    if (!category.goal_type) {
+      throw ToolError.validation(`Category "${category.name}" has no goal to snooze.`);
+    }
+
+    const existing = (budget.changed_entities?.be_monthly_subcategory_budgets ?? []).find(
+      b => b.id === budgetId && notTombstone(b),
+    );
+
+    const snoozedAt = shouldSnooze ? new Date().toISOString() : null;
+    // Preserve every field on the existing budget row so we don't accidentally
+    // wipe state by sending only the fields we care about.
+    const budgetEntry: RawMonthlySubcategoryBudget = {
+      ...(existing ?? {}),
+      id: budgetId,
+      is_tombstone: false,
+      entities_monthly_budget_id: monthlyBudgetId,
+      entities_subcategory_id: params.category_id,
+      budgeted: existing?.budgeted ?? 0,
+      goal_snoozed_at: snoozedAt,
+    };
+
+    await syncWrite<BudgetEntities>(planId, { be_monthly_subcategory_budgets: [budgetEntry] }, serverKnowledge);
+
+    return { success: true, snoozed_at: snoozedAt };
+  },
+});

--- a/plugins/ynab/src/tools/update-category-budget.ts
+++ b/plugins/ynab/src/tools/update-category-budget.ts
@@ -1,4 +1,4 @@
-import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
+import { defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { getPlanId, getUserId, syncBudget, syncWrite } from '../ynab-api.js';
 import type { BudgetEntities, RawMonthlySubcategoryBudget } from './schemas.js';
@@ -6,6 +6,7 @@ import {
   buildSubcategoryBudgetMap,
   buildSubcategoryCalcMap,
   categorySchema,
+  findCategory,
   formatMonthlyBudgetId,
   formatSubcategoryBudgetId,
   MONEY_MOVEMENT_SOURCE,
@@ -44,12 +45,7 @@ export const updateCategoryBudget = defineTool({
 
     const budget = await syncBudget<BudgetEntities>(planId);
     const serverKnowledge = budget.current_server_knowledge ?? 0;
-    const category = (budget.changed_entities?.be_subcategories ?? []).find(
-      c => c.id === params.category_id && notTombstone(c),
-    );
-    if (!category) {
-      throw ToolError.notFound(`Category not found: ${params.category_id}`);
-    }
+    const category = findCategory(budget.changed_entities, params.category_id);
 
     const existingBudget = (budget.changed_entities?.be_monthly_subcategory_budgets ?? []).find(
       b => b.id === budgetId && notTombstone(b),

--- a/plugins/ynab/src/tools/update-category.ts
+++ b/plugins/ynab/src/tools/update-category.ts
@@ -1,8 +1,9 @@
-import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
 import type { BudgetEntities, RawCategory } from './schemas.js';
 import {
+  assertCategoryGroupDeletable,
   buildGoalFields,
   categorySchema,
   findCategory,
@@ -37,7 +38,12 @@ export const updateCategory = defineTool({
     const serverKnowledge = budget.current_server_knowledge ?? 0;
 
     const existing = findCategory(budget.changed_entities, params.category_id);
-    if (params.group_id) findCategoryGroup(budget.changed_entities, params.group_id);
+    if (params.group_id) {
+      assertCategoryGroupDeletable(findCategoryGroup(budget.changed_entities, params.group_id));
+    }
+    if (params.goal?.type === 'debt' && existing.entities_account_id == null) {
+      throw ToolError.validation('Debt goals can only be set on debt-account categories.');
+    }
 
     const updated: RawCategory = {
       ...existing,

--- a/plugins/ynab/src/tools/update-category.ts
+++ b/plugins/ynab/src/tools/update-category.ts
@@ -1,0 +1,55 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { getPlanId, syncBudget, syncWrite } from '../ynab-api.js';
+import type { BudgetEntities, RawCategory } from './schemas.js';
+import {
+  buildGoalFields,
+  categorySchema,
+  findCategory,
+  findCategoryGroup,
+  goalSpecSchema,
+  mapCategory,
+} from './schemas.js';
+
+export const updateCategory = defineTool({
+  name: 'update_category',
+  displayName: 'Update Category',
+  description:
+    'Rename a category, change its group, set/clear its goal, or hide/unhide it. Only specified fields change; omitted fields remain unchanged. Goal types: "set_aside" / "refill" (recurring NEED with optional cadence), "target_balance" (have $X), "target_by_date" (have $X by date), "debt" (recurring debt payment), or "none" to clear an existing goal.',
+  summary: 'Update a category',
+  icon: 'pencil',
+  group: 'Categories',
+  input: z.object({
+    category_id: z.string().min(1).describe('Category ID to update'),
+    name: z.string().min(1).optional().describe('New name'),
+    group_id: z.string().min(1).optional().describe('New parent category group ID (to move the category)'),
+    goal: goalSpecSchema.optional().describe('New goal definition. Pass { type: "none" } to clear the goal.'),
+    hidden: z.boolean().optional().describe('Hide or unhide the category'),
+    note: z.string().optional().describe('New note (pass empty string to clear)'),
+  }),
+  output: z.object({
+    category: categorySchema,
+  }),
+  handle: async params => {
+    const planId = getPlanId();
+
+    const budget = await syncBudget<BudgetEntities>(planId);
+    const serverKnowledge = budget.current_server_knowledge ?? 0;
+
+    const existing = findCategory(budget.changed_entities, params.category_id);
+    if (params.group_id) findCategoryGroup(budget.changed_entities, params.group_id);
+
+    const updated: RawCategory = {
+      ...existing,
+      name: params.name ?? existing.name,
+      entities_master_category_id: params.group_id ?? existing.entities_master_category_id,
+      is_hidden: params.hidden ?? existing.is_hidden,
+      note: params.note ?? existing.note,
+      ...(params.goal !== undefined ? buildGoalFields(params.goal) : {}),
+    };
+
+    await syncWrite<BudgetEntities>(planId, { be_subcategories: [updated] }, serverKnowledge);
+
+    return { category: mapCategory(updated) };
+  },
+});


### PR DESCRIPTION
## Summary

Adds six new tools to the YNAB plugin for full category lifecycle management:

- **`create_category`** — create a category in an existing group, with optional goal (set_aside, refill, target_balance, target_by_date, debt) and full cadence support (weekly/monthly/yearly)
- **`update_category`** — rename, move to a different group, set/clear goal, hide/unhide, update note
- **`delete_category`** — soft-delete (tombstone) a category
- **`create_category_group`** — create a new category group
- **`delete_category_group`** — soft-delete a group and all its children; blocks deletion of internal groups (Credit Card Payments, Hidden Categories, etc.)
- **`snooze_category_goal`** — snooze or un-snooze a category goal for a specific month

Also includes supporting schema changes:

- `goalSpecSchema` discriminated union covering all YNAB goal types with Zod validation (including yearly cadence requiring `start_date`)
- `buildGoalFields()` translates goal specs to YNAB wire fields
- Shared `findCategory` / `findCategoryGroup` lookup helpers with `ToolError.notFound`
- `nextTopSortableIndex` helper for ordering new entities at the top
- Fix `goal_target` in `mapCategory` to read `goal_target_amount` (the user-configured target) instead of the calc's dynamic "needed this month" — fixes misleading values for refill goals
- Add `goal_snoozed_at` to `RawMonthlySubcategoryBudget`
- Refactor `update_category_budget` to use the shared `findCategory` helper

## Test plan

- [ ] `create_category` with no goal, with each goal type, and with yearly cadence + `start_date`
- [ ] `update_category` — rename, move group, set goal, clear goal (`type: "none"`), hide/unhide
- [ ] `delete_category` — verify it tombstones and disappears from budget views
- [ ] `create_category_group` — verify it appears in the YNAB UI
- [ ] `delete_category_group` — verify child categories are also tombstoned; verify internal groups are blocked
- [ ] `snooze_category_goal` — verify goal shows as snoozed; un-snooze restores it
- [ ] `goal_target` on `list_categories` returns the configured target, not the dynamic "needed this month"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, update, and delete categories within groups.
  * Create and delete category groups.
  * Snooze or unsnooze category goals for a specific month.
  * Configure richer category goals (target amounts, cadence, and goal behavior).
* **Bug Fixes / Validation**
  * Added stricter validation and safeguards for category/group operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->