### PR TITLE
fix: resolve getCliVersion() package.json path for global npm installs

### DIFF
--- a/platform/cli/package.json
+++ b/platform/cli/package.json
@@ -18,6 +18,7 @@
   },
   "type": "module",
   "exports": {
+    "./package.json": "./package.json",
     "./scaffold": {
       "types": "./dist/scaffold.d.ts",
       "import": "./dist/scaffold.js"

--- a/platform/cli/src/version-info.ts
+++ b/platform/cli/src/version-info.ts
@@ -5,7 +5,12 @@ import { fileURLToPath } from 'node:url';
 const cliDir = dirname(fileURLToPath(import.meta.url));
 
 export const getCliVersion = async (): Promise<string> => {
-  const pkgPath = join(cliDir, '..', '..', 'package.json');
+  let pkgPath: string;
+  try {
+    pkgPath = fileURLToPath(import.meta.resolve('@opentabs-dev/cli/package.json'));
+  } catch {
+    pkgPath = join(cliDir, '..', '..', 'package.json');
+  }
   const pkgJson = JSON.parse(await readFile(pkgPath, 'utf-8')) as { version: string };
   return pkgJson.version;
 };


### PR DESCRIPTION
## Problem

`opentabs start` crashes for all global npm installs:

```
Error: ENOENT: no such file or directory, open '.../node_modules/@opentabs-dev/package.json'
```

`getCliVersion()` resolves `package.json` two directories up from the compiled output. In the monorepo this lands at `platform/package.json` ✓, but after a global install the code lives at `node_modules/@opentabs-dev/cli/dist/` — two levels up is the scope directory, which has no `package.json`.

## Fix

Uses `import.meta.resolve` (same pattern as `getMcpServerVersion`) with the existing relative path as a dev fallback. Also adds `./package.json` to the `exports` field in `cli/package.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the CLI's version detection mechanism to use a more robust approach for locating and reading version information with automatic fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->