### PR TITLE
fix(outlook): add Trusted Types policy and extend auth timeout

### DIFF
--- a/plugins/outlook/src/index.ts
+++ b/plugins/outlook/src/index.ts
@@ -4,8 +4,18 @@
 // succeed silently instead of logging a console violation.
 if (typeof window !== 'undefined') {
   try {
-    const tt = (window as unknown as { trustedTypes?: { createPolicy?: (name: string, rules: Record<string, (s: string) => string>) => void } }).trustedTypes;
-    tt?.createPolicy?.('default', { createScript: (s: string) => s });
+    const tt = (window as Window & {
+      trustedTypes?: TrustedTypePolicyFactory & { defaultPolicy?: TrustedTypePolicy | null };
+    }).trustedTypes;
+    if (tt && !tt.defaultPolicy) {
+      tt.createPolicy('default', {
+        createScript: (s: string) => {
+          // Only allow the empty-string probe used by zod's allowsEval feature-detect.
+          if (s !== '') throw new TypeError('Blocked Trusted Types script conversion');
+          return s;
+        },
+      });
+    }
   } catch {
     // 'default' policy already exists, or Trusted Types not supported — safe to ignore.
   }

--- a/plugins/outlook/src/index.ts
+++ b/plugins/outlook/src/index.ts
@@ -1,7 +1,8 @@
-// Outlook enforces Trusted Types (CSP). Zod's allowsEval probe calls
-// new Function("") which requires a 'default' Trusted Types policy to exist.
-// Creating it here (before any zod code runs) lets the try/catch in zod
-// succeed silently instead of logging a console violation.
+// Outlook on cloud.microsoft enforces Trusted Types (CSP). Zod's allowsEval
+// feature-detect calls new Function("") the first time a zod parser runs
+// (lazy, memoized via cached()). This policy just needs to exist before that
+// first runtime call — import statements are hoisted regardless, but the probe
+// only fires when a tool handler first invokes a zod schema at runtime.
 if (typeof window !== 'undefined') {
   try {
     const tt = (window as Window & {

--- a/plugins/outlook/src/index.ts
+++ b/plugins/outlook/src/index.ts
@@ -1,3 +1,16 @@
+// Outlook enforces Trusted Types (CSP). Zod's allowsEval probe calls
+// new Function("") which requires a 'default' Trusted Types policy to exist.
+// Creating it here (before any zod code runs) lets the try/catch in zod
+// succeed silently instead of logging a console violation.
+if (typeof window !== 'undefined') {
+  try {
+    const tt = (window as unknown as { trustedTypes?: { createPolicy?: (name: string, rules: Record<string, (s: string) => string>) => void } }).trustedTypes;
+    tt?.createPolicy?.('default', { createScript: (s: string) => s });
+  } catch {
+    // 'default' policy already exists, or Trusted Types not supported — safe to ignore.
+  }
+}
+
 import { OpenTabsPlugin } from '@opentabs-dev/plugin-sdk';
 import type { ToolDefinition } from '@opentabs-dev/plugin-sdk';
 import { isAuthenticated, waitForAuth } from './outlook-api.js';

--- a/plugins/outlook/src/outlook-api.ts
+++ b/plugins/outlook/src/outlook-api.ts
@@ -158,10 +158,17 @@ const getAuth = (): OutlookAuth | null => {
   return auth;
 };
 
-export const isAuthenticated = (): boolean => getAuth() !== null;
+export const isAuthenticated = (): boolean => {
+  // During OAuth redirect the #code= fragment is present but MSAL tokens are
+  // not yet in localStorage. Return false early so the platform's 30s re-poll
+  // catches the token once the handshake completes, rather than burning the
+  // 5s isReady window on token searches that will all fail.
+  if (typeof window !== 'undefined' && window.location.hash.includes('code=')) return false;
+  return getAuth() !== null;
+};
 
 export const waitForAuth = (): Promise<boolean> =>
-  waitUntil(() => isAuthenticated(), { interval: 500, timeout: 30000 }).then(
+  waitUntil(() => isAuthenticated(), { interval: 500, timeout: 5000 }).then(
     () => true,
     () => false,
   );

--- a/plugins/outlook/src/outlook-api.ts
+++ b/plugins/outlook/src/outlook-api.ts
@@ -161,7 +161,7 @@ const getAuth = (): OutlookAuth | null => {
 export const isAuthenticated = (): boolean => getAuth() !== null;
 
 export const waitForAuth = (): Promise<boolean> =>
-  waitUntil(() => isAuthenticated(), { interval: 500, timeout: 5000 }).then(
+  waitUntil(() => isAuthenticated(), { interval: 500, timeout: 30000 }).then(
     () => true,
     () => false,
   );


### PR DESCRIPTION
Outlook on cloud.microsoft enforces a Trusted Types CSP policy that causes zod's allowsEval probe (new Function("")) to log a console violation. Creating a 'default' Trusted Types policy before any zod code runs lets the probe complete silently via its existing try/catch.

Also extends waitForAuth timeout from 5000ms to 30000ms. When Outlook redirects through an OAuth flow (#code= URL fragment), MSAL tokens are not yet in localStorage when the adapter first initializes. The previous 5s window was too short for the OAuth handshake to complete on slower connections or enterprise SSO flows.

Fixes two issues reported in [issue #<nummer>] affecting Outlook on `cloud.microsoft`:

## Changes

### 1. Trusted Types policy (`index.ts`)
Outlook enforces a Trusted Types CSP. Zod's `allowsEval` probe calls
`new Function("")` which triggers a console violation. Creating a `default`
Trusted Types policy before any zod code runs lets the probe complete
silently via its existing try/catch.

### 2. Extended auth timeout (`outlook-api.ts`)
`waitForAuth` timeout increased from 5000ms → 30000ms.

When Outlook loads via an OAuth redirect (`#code=` URL fragment), MSAL tokens
are not yet in localStorage when the adapter first initializes. The 5s window
was too short for the OAuth handshake + token storage to complete, causing
`isReady()` to return false permanently.

## Test environment
- Microsoft 365 work/school account (enterprise tenant)
- `https://outlook.cloud.microsoft/mail/`
- Chrome + OpenTabs extension v0.0.103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a runtime Trusted Types policy to tighten script handling and avoid startup interruptions if policy setup fails.

* **Bug Fixes**
  * Defer token cache checks during the OAuth redirect phase to prevent premature authentication failures and improve sign-in reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->