### PR TITLE
feat(mcp-server): emit browser_screenshot_tab as MCP image content part

### DIFF
--- a/docs/content/docs/reference/browser-tools.mdx
+++ b/docs/content/docs/reference/browser-tools.mdx
@@ -158,7 +158,7 @@ These are all the browser tools your AI agent gets automatically when OpenTabs i
     </Table.Row>
     <Table.Row>
       <Table.Cell className="font-medium">`browser_screenshot_tab`</Table.Cell>
-      <Table.Cell>Capture a screenshot of the visible tab area as a base64-encoded PNG. Auto-focuses the tab before capture.</Table.Cell>
+      <Table.Cell>Capture a screenshot of the visible tab area as a PNG, returned as an MCP image content part. Auto-focuses the tab before capture.</Table.Cell>
     </Table.Row>
   </Table.Body>
 </Table>

--- a/e2e/browser-tools.e2e.ts
+++ b/e2e/browser-tools.e2e.ts
@@ -1156,7 +1156,7 @@ test.describe('browser_get_tab_info', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('browser_screenshot_tab', () => {
-  test('captures a base64 PNG screenshot', async ({
+  test('returns a single PNG image content part', async ({
     mcpServer,
     testServer,
     extensionContext: _extensionContext,
@@ -1165,27 +1165,53 @@ test.describe('browser_screenshot_tab', () => {
     await initAndListTools(mcpServer, mcpClient);
     const tabId = await openTestServerTab(mcpClient, testServer);
 
-    // Poll until screenshot returns a valid PNG (page fully rendered)
-    let data: Record<string, unknown> = {};
+    // Poll until screenshot returns a valid PNG image content part (page fully rendered).
+    // The tool emits `[{type:'image', data:<base64 PNG>, mimeType:'image/png'}]`, so we
+    // assert on the raw contentParts array rather than the joined text content.
+    //
+    // Local literal-union for `type` (rather than the wider `string` on the McpClient
+    // contract) so a future drift — e.g. a new content kind landing in this tool's
+    // response, or `mimeType` becoming optional — is caught at compile time. We
+    // deliberately don't import `ToolContentPart` from the MCP server source: these
+    // E2E tests treat the server as a black-box subprocess over JSON-RPC and assert
+    // on the observable wire shape, so depending on a server-internal type would
+    // couple the test harness to server internals rather than the wire contract.
+    type ScreenshotPart = { type: 'image' | 'text'; data?: string; mimeType?: string; text?: string };
+    let parts: ScreenshotPart[] = [];
     await waitFor(
       async () => {
         try {
           const r = await mcpClient.callTool('browser_screenshot_tab', { tabId });
           if (r.isError) return false;
-          data = parseToolResult(r.content);
-          return typeof data.image === 'string' && data.image.startsWith('iVBOR');
+          // Defensive default: callTool guarantees contentParts is an array (see
+          // fixtures.test.ts), but if that contract ever drifts the poll would
+          // otherwise swallow a TypeError in the catch and silently retry to
+          // timeout with a misleading failure message. The cast narrows the
+          // server-wide `type: string` to the literal union this test expects;
+          // non-image/text parts would still trip the assertions below.
+          parts = (r.contentParts ?? []) as ScreenshotPart[];
+          const first = parts[0];
+          return (
+            parts.length === 1 &&
+            first?.type === 'image' &&
+            typeof first.data === 'string' &&
+            first.data.startsWith('iVBOR')
+          );
         } catch {
           return false;
         }
       },
       10_000,
       300,
-      'screenshot returns valid PNG',
+      'screenshot returns valid PNG image content part',
     );
 
-    expect(typeof data.image).toBe('string');
+    expect(parts).toHaveLength(1);
+    expect(parts[0]?.type).toBe('image');
+    expect(parts[0]?.mimeType).toBe('image/png');
     // PNG files encoded in base64 start with 'iVBOR' (the base64 encoding of the PNG header)
-    expect((data.image as string).startsWith('iVBOR')).toBe(true);
+    expect(typeof parts[0]?.data).toBe('string');
+    expect((parts[0]?.data as string).startsWith('iVBOR')).toBe(true);
 
     // Clean up
     await mcpClient.callTool('browser_close_tab', { tabId });

--- a/e2e/fixtures.test.ts
+++ b/e2e/fixtures.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the in-process MCP client used by E2E fixtures.
+ *
+ * These exercise the JSON / SSE response parsing in `createMcpClient`
+ * without spinning up the real MCP server — `globalThis.fetch` is stubbed
+ * per test. Anything more involved (session lifecycle, retry-after-restart,
+ * extension dispatch) is covered by the Playwright E2E suites.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createMcpClient } from './fixtures.js';
+
+interface MockFetchResponse {
+  ok: boolean;
+  status?: number;
+  headers: Headers;
+  json?: () => Promise<unknown>;
+  text?: () => Promise<string>;
+}
+
+const jsonResponse = (body: unknown): MockFetchResponse => ({
+  ok: true,
+  status: 200,
+  headers: new Headers({ 'content-type': 'application/json' }),
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+});
+
+const sseResponse = (lines: string[]): MockFetchResponse => ({
+  ok: true,
+  status: 200,
+  headers: new Headers({ 'content-type': 'text/event-stream' }),
+  text: async () => lines.join('\n'),
+});
+
+describe('createMcpClient', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('callTool', () => {
+    test('preserves the full contentParts array (text + image) and joins only text into `content`', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            content: [
+              { type: 'text', text: 'narrative ' },
+              { type: 'image', data: 'IMG', mimeType: 'image/png' },
+            ],
+            isError: false,
+          },
+        }),
+      );
+
+      const client = createMcpClient(0);
+      const r = await client.callTool('foo');
+
+      expect(r.isError).toBe(false);
+      expect(r.content).toBe('narrative ');
+      expect(r.contentParts).toHaveLength(2);
+      expect(r.contentParts[1]).toEqual({ type: 'image', data: 'IMG', mimeType: 'image/png' });
+    });
+
+    test('error response: contentParts is always an array (never undefined)', async () => {
+      // The contract this test pins: `contentParts` is the array consumers can
+      // safely index into without undefined-handling. The polling logic in the
+      // E2E suites relies on it.
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: -32000, message: 'dispatch timeout' },
+        }),
+      );
+
+      const client = createMcpClient(0);
+      const r = await client.callTool('foo');
+
+      expect(r.isError).toBe(true);
+      expect(r.content).toBe('dispatch timeout');
+      expect(Array.isArray(r.contentParts)).toBe(true);
+      expect(r.contentParts).toEqual([]);
+    });
+  });
+
+  describe('callToolWithProgress', () => {
+    test('JSON response: joins only text parts into `content` and preserves all parts in `contentParts`', async () => {
+      // Mixed-content tool result: text + image + text. The SSE/JSON helper
+      // must mirror the contract introduced in `callTool`: `content` is the
+      // joined text-only payload; `contentParts` is the raw array.
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            content: [
+              { type: 'text', text: 'before ' },
+              { type: 'image', data: 'IMG', mimeType: 'image/png' },
+              { type: 'text', text: 'after' },
+            ],
+            isError: false,
+          },
+        }),
+      );
+
+      const client = createMcpClient(0);
+      const r = await client.callToolWithProgress('foo');
+
+      expect(r.isError).toBe(false);
+      expect(r.content).toBe('before after');
+      expect(r.contentParts).toHaveLength(3);
+      expect(r.contentParts[1]).toEqual({ type: 'image', data: 'IMG', mimeType: 'image/png' });
+      expect(r.progressNotifications).toEqual([]);
+    });
+
+    test('SSE response: extracts progress notifications and parses tool result with full contentParts', async () => {
+      fetchMock.mockResolvedValueOnce(
+        sseResponse([
+          'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"t","progress":1,"total":2,"message":"halfway"}}',
+          '',
+          'data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"hi"},{"type":"image","data":"IMG","mimeType":"image/png"}],"isError":false}}',
+          '',
+        ]),
+      );
+
+      const client = createMcpClient(0);
+      const r = await client.callToolWithProgress('foo');
+
+      expect(r.isError).toBe(false);
+      expect(r.content).toBe('hi');
+      expect(r.contentParts).toHaveLength(2);
+      expect(r.contentParts[1]?.type).toBe('image');
+      expect(r.progressNotifications).toEqual([{ progress: 1, total: 2, message: 'halfway' }]);
+    });
+
+    test('JSON error response: returns isError with empty contentParts', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: -32000, message: 'dispatch timeout' },
+        }),
+      );
+
+      const client = createMcpClient(0);
+      const r = await client.callToolWithProgress('foo');
+
+      expect(r.isError).toBe(true);
+      expect(r.content).toBe('dispatch timeout');
+      expect(Array.isArray(r.contentParts)).toBe(true);
+      expect(r.contentParts).toEqual([]);
+    });
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1070,18 +1070,39 @@ interface McpClient {
   initialize: () => Promise<void>;
   /** List all registered tools via `tools/list`. */
   listTools: () => Promise<Array<{ name: string; description: string; inputSchema?: unknown }>>;
-  /** Call a tool via `tools/call` and return the concatenated text content. */
+  /**
+   * Call a tool via `tools/call` and return the concatenated text content
+   * plus the raw content-part array. `content` joins every text part; image,
+   * audio, and other non-text parts are not included in `content` (their
+   * payloads are not text). Tests that need to assert on non-text parts
+   * (e.g. screenshot returns an `image` content part) should read
+   * `contentParts` directly.
+   */
   callTool: (
     name: string,
     args?: Record<string, unknown>,
     options?: { timeout?: number },
-  ) => Promise<{ content: string; isError: boolean }>;
-  /** Call a tool with a progressToken and capture all progress notifications from the SSE stream. */
+  ) => Promise<{
+    content: string;
+    isError: boolean;
+    contentParts: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+  }>;
+  /**
+   * Call a tool with a progressToken and capture all progress notifications
+   * from the SSE stream. Returns the same content / contentParts shape as
+   * `callTool` so callers observe a single contract regardless of whether
+   * the response arrives over JSON or SSE.
+   */
   callToolWithProgress: (
     name: string,
     args?: Record<string, unknown>,
     options?: { timeout?: number },
-  ) => Promise<{ content: string; isError: boolean; progressNotifications: ProgressNotification[] }>;
+  ) => Promise<{
+    content: string;
+    isError: boolean;
+    progressNotifications: ProgressNotification[];
+    contentParts: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+  }>;
   /** Close the MCP session by sending a DELETE request. */
   close: () => Promise<void>;
   /** Reset the session so the next initialize() creates a fresh session. */
@@ -1267,15 +1288,18 @@ const createMcpClient = (port: number, secret?: string): McpClient => {
       // Handle JSON-RPC error responses (e.g. dispatch timeout)
       if (res.error) {
         const err = res.error as { message: string };
-        return { content: err.message, isError: true };
+        return { content: err.message, isError: true, contentParts: [] };
       }
 
       const result = res.result as {
-        content: Array<{ type: string; text: string }>;
+        content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
         isError?: boolean;
       };
-      const text = result.content.map(c => c.text).join('');
-      return { content: text, isError: result.isError === true };
+      const text = result.content
+        .filter(c => c.type === 'text' && typeof c.text === 'string')
+        .map(c => c.text as string)
+        .join('');
+      return { content: text, isError: result.isError === true, contentParts: result.content };
     },
 
     callToolWithProgress: async (name, args = {}, options) => {
@@ -1321,14 +1345,22 @@ const createMcpClient = (port: number, secret?: string): McpClient => {
         const json = (await res.json()) as Record<string, unknown>;
         if (json.error) {
           const err = json.error as { message: string };
-          return { content: err.message, isError: true, progressNotifications };
+          return { content: err.message, isError: true, progressNotifications, contentParts: [] };
         }
         const result = json.result as {
-          content: Array<{ type: string; text: string }>;
+          content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
           isError?: boolean;
         };
-        const text = result.content.map(c => c.text).join('');
-        return { content: text, isError: result.isError === true, progressNotifications };
+        const text = result.content
+          .filter(c => c.type === 'text' && typeof c.text === 'string')
+          .map(c => c.text as string)
+          .join('');
+        return {
+          content: text,
+          isError: result.isError === true,
+          progressNotifications,
+          contentParts: result.content,
+        };
       }
 
       // SSE response — parse all messages, extracting progress notifications
@@ -1372,15 +1404,23 @@ const createMcpClient = (port: number, secret?: string): McpClient => {
 
       if (toolResult.error) {
         const err = toolResult.error as { message: string };
-        return { content: err.message, isError: true, progressNotifications };
+        return { content: err.message, isError: true, progressNotifications, contentParts: [] };
       }
 
       const result = toolResult.result as {
-        content: Array<{ type: string; text: string }>;
+        content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
         isError?: boolean;
       };
-      const text = result.content.map(c => c.text).join('');
-      return { content: text, isError: result.isError === true, progressNotifications };
+      const text = result.content
+        .filter(c => c.type === 'text' && typeof c.text === 'string')
+        .map(c => c.text as string)
+        .join('');
+      return {
+        content: text,
+        isError: result.isError === true,
+        progressNotifications,
+        contentParts: result.content,
+      };
     },
 
     close: async () => {

--- a/platform/cli/src/commands/tool.test.ts
+++ b/platform/cli/src/commands/tool.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
-import { readParamsSource } from './tool.js';
+import { readParamsSource, renderToolCallContent } from './tool.js';
 
 let dir: string;
 beforeAll(async () => {
@@ -104,5 +104,59 @@ describe('readParamsSource', () => {
     const parsed = JSON.parse(result?.json ?? '') as { data: string };
     expect(parsed.data.length).toBe(2 * 1024 * 1024);
     expect(parsed.data).toBe(bigString);
+  });
+});
+
+describe('renderToolCallContent', () => {
+  test('image part calls saveImage and renders a human summary with the saved path', () => {
+    const saveImage = vi.fn().mockReturnValue('/tmp/opentabs-shot.png');
+    const out = renderToolCallContent([{ type: 'image', data: 'AAAABBBB', mimeType: 'image/png' }], saveImage);
+    expect(saveImage).toHaveBeenCalledWith('AAAABBBB', 'image/png', 0);
+    expect(out).toContain('image/png');
+    expect(out).toContain('/tmp/opentabs-shot.png');
+  });
+
+  test('single text part renders as text verbatim without touching saveImage', () => {
+    const saveImage = vi.fn();
+    expect(renderToolCallContent([{ type: 'text', text: 'hello' }], saveImage)).toBe('hello');
+    expect(saveImage).not.toHaveBeenCalled();
+  });
+
+  test('combined text + image: text line first, image summary second', () => {
+    const saveImage = vi.fn().mockReturnValue('/tmp/shot.png');
+    const out = renderToolCallContent(
+      [
+        { type: 'text', text: 'preamble' },
+        { type: 'image', data: 'AAAA', mimeType: 'image/png' },
+      ],
+      saveImage,
+    );
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('preamble');
+    expect(lines[1]).toContain('/tmp/shot.png');
+  });
+
+  test('unsupported content part type is reported, not silently dropped', () => {
+    const saveImage = vi.fn();
+    const out = renderToolCallContent([{ type: 'audio' }], saveImage);
+    expect(out).toContain('unsupported');
+    expect(out).toContain('audio');
+  });
+
+  test('malformed image part (missing mimeType) is reported; saveImage not called', () => {
+    const saveImage = vi.fn();
+    const out = renderToolCallContent([{ type: 'image', data: 'AAAA' }], saveImage);
+    expect(saveImage).not.toHaveBeenCalled();
+    expect(out).toContain('malformed');
+  });
+
+  test('malformed text part (missing text) is reported, not silently emitted as empty line', () => {
+    const saveImage = vi.fn();
+    // type=text but no text field — flag it the same way image malformations are flagged,
+    // so a server-side bug producing this shape doesn't disappear into a blank line.
+    const out = renderToolCallContent([{ type: 'text' }], saveImage);
+    expect(out).toContain('malformed');
+    expect(out).toContain('text');
+    expect(saveImage).not.toHaveBeenCalled();
   });
 });

--- a/platform/cli/src/commands/tool.ts
+++ b/platform/cli/src/commands/tool.ts
@@ -2,7 +2,10 @@
  * `opentabs tool` command — discover and invoke tools from the running server.
  */
 
+import { writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { DEFAULT_HOST, toErrorMessage } from '@opentabs-dev/shared';
 import type { Command } from 'commander';
 import pc from 'picocolors';
@@ -110,8 +113,23 @@ const handleToolList = async (options: ToolListOptions): Promise<void> => {
   }
 };
 
+/**
+ * Loose content-part shape for defensive parsing of tool-call responses.
+ * Diverges intentionally from the server's strict `ToolContentPart` discriminated
+ * union (in `@opentabs-dev/shared` once exported, currently in mcp-server's
+ * browser-tools/definition.ts): `type` is widened to `string` and the variant
+ * fields are optional so a server emitting an unknown or partial part does not
+ * crash the CLI before it can report it.
+ */
+interface ToolCallContentPart {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
 interface ToolCallResult {
-  content: Array<{ type: string; text: string }>;
+  content: ToolCallContentPart[];
   isError?: boolean;
 }
 
@@ -156,6 +174,53 @@ export const readParamsSource = async (
   if (jsonArg !== undefined) return { json: jsonArg, origin: '[json]' };
   return undefined;
 };
+
+/** Map a MIME type to a conventional file extension for saved image files */
+const extForMime = (mimeType: string): string => {
+  if (mimeType === 'image/png') return 'png';
+  if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/webp') return 'webp';
+  if (mimeType === 'image/gif') return 'gif';
+  return 'bin';
+};
+
+/**
+ * Render an MCP tool-call content array for display at the terminal.
+ * Text parts are returned verbatim. Image parts are written to disk via the
+ * injected `saveImage` callback and summarised as a line referencing the
+ * saved path. Unknown or malformed parts are reported rather than silently
+ * dropped, so the user sees that something non-text came back.
+ */
+const renderToolCallContent = (
+  content: ToolCallContentPart[],
+  saveImage: (data: string, mimeType: string, index: number) => string,
+): string => {
+  const lines: string[] = [];
+  content.forEach((part, i) => {
+    if (part.type === 'text') {
+      if (typeof part.text !== 'string') {
+        lines.push(`[malformed text content part at index ${i}]`);
+        return;
+      }
+      lines.push(part.text);
+      return;
+    }
+    if (part.type === 'image') {
+      if (typeof part.data !== 'string' || typeof part.mimeType !== 'string') {
+        lines.push(`[malformed image content part at index ${i}]`);
+        return;
+      }
+      const path = saveImage(part.data, part.mimeType, i);
+      const bytes = Math.floor((part.data.length * 3) / 4);
+      lines.push(`[image: type=${part.mimeType}, ~${bytes} bytes, saved to ${path}]`);
+      return;
+    }
+    lines.push(`[unsupported content part at index ${i}: type=${part.type}]`);
+  });
+  return lines.join('\n');
+};
+
+export { renderToolCallContent };
 
 const handleToolCall = async (
   name: string,
@@ -220,22 +285,46 @@ const handleToolCall = async (
 
   const result = (await res.json()) as ToolCallResult;
 
-  // Extract text content from the result
-  const texts = result.content.filter(c => c.type === 'text').map(c => c.text);
-  const output = texts.join('\n');
+  // Save image content parts to tmpdir so their paths can be reported to the user.
+  // The tool name is user-supplied and could contain path separators or characters
+  // that are invalid on the host OS, so sanitize it before composing the filename
+  // to prevent path traversal and unwritable paths. A failed write (e.g. full disk,
+  // permissions) is wrapped so the caller gets a readable error rather than a crash.
+  const safeName = name.replace(/[^A-Za-z0-9._-]/g, '-').slice(0, 64) || 'tool';
+  const saveImage = (data: string, mimeType: string, index: number): string => {
+    const ext = extForMime(mimeType);
+    const filename = `opentabs-${safeName}-${Date.now()}-${index}.${ext}`;
+    const path = join(tmpdir(), filename);
+    try {
+      writeFileSync(path, Buffer.from(data, 'base64'));
+    } catch (err) {
+      throw new Error(
+        `Failed to save image content part (mimeType=${mimeType}, target=${path}): ${toErrorMessage(err)}`,
+      );
+    }
+    return path;
+  };
+
+  const output = renderToolCallContent(result.content, saveImage);
 
   if (result.isError) {
     console.error(output);
     process.exit(1);
   }
 
-  // Print result to stdout — try to pretty-print if it's valid JSON
-  try {
-    const parsed: unknown = JSON.parse(output);
-    console.log(JSON.stringify(parsed, null, 2));
-  } catch {
-    console.log(output);
+  // Pretty-print text-only output if it parses as JSON. Mixed or image-bearing
+  // output is not JSON-parseable and is printed verbatim.
+  const textOnly = result.content.length === 1 && result.content[0]?.type === 'text';
+  if (textOnly) {
+    try {
+      const parsed: unknown = JSON.parse(output);
+      console.log(JSON.stringify(parsed, null, 2));
+      return;
+    } catch {
+      // fall through to plain print
+    }
   }
+  console.log(output);
 };
 
 const handleToolSchema = async (name: string, options: { port?: number }): Promise<void> => {

--- a/platform/mcp-server/src/browser-tools/definition.ts
+++ b/platform/mcp-server/src/browser-tools/definition.ts
@@ -14,6 +14,25 @@
 import type { z } from 'zod';
 import type { ServerState } from '../state.js';
 
+/** Text content part — JSON-stringified handler output is wrapped in this by default */
+interface TextContentPart {
+  type: 'text';
+  text: string;
+}
+
+/**
+ * Image content part — used by tools that return binary image data (e.g. screenshots).
+ * MCP clients decode this directly, so the payload is not subject to text-result spilling.
+ */
+interface ImageContentPart {
+  type: 'image';
+  data: string;
+  mimeType: string;
+}
+
+/** Union of content parts a browser tool may produce via formatResult */
+type ToolContentPart = TextContentPart | ImageContentPart;
+
 /** A browser tool definition with Zod input schema and a handler */
 interface BrowserToolDefinition<TInput extends z.ZodObject = z.ZodObject> {
   name: string;
@@ -26,6 +45,14 @@ interface BrowserToolDefinition<TInput extends z.ZodObject = z.ZodObject> {
   group?: string;
   input: TInput;
   handler: (args: z.infer<TInput>, state: ServerState) => Promise<unknown>;
+  /**
+   * Optional formatter that converts the sanitized handler result into MCP content parts.
+   * When omitted, the dispatcher wraps the JSON-stringified result as a single text part.
+   * Tools that return binary payloads (images, audio) define this to emit the appropriate
+   * MCP content part directly, avoiding the text-payload path that triggers client-side
+   * spill-to-file when results exceed inline size caps.
+   */
+  formatResult?: (result: unknown) => ToolContentPart[];
 }
 
 /** Type-safe factory for defining browser tools */
@@ -33,5 +60,5 @@ const defineBrowserTool = <TInput extends z.ZodObject>(
   config: BrowserToolDefinition<TInput>,
 ): BrowserToolDefinition<TInput> => config;
 
-export type { BrowserToolDefinition };
+export type { BrowserToolDefinition, ImageContentPart, TextContentPart, ToolContentPart };
 export { defineBrowserTool };

--- a/platform/mcp-server/src/browser-tools/screenshot-tab.test.ts
+++ b/platform/mcp-server/src/browser-tools/screenshot-tab.test.ts
@@ -1,101 +1,99 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { WsHandle } from '@opentabs-dev/shared';
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
-import type { ExtensionConnection, ServerState } from '../state.js';
-import { createState } from '../state.js';
-import { screenshotTab } from './screenshot-tab.js';
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
-const SAMPLE_PNG_BASE64 =
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
-const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const { mockDispatchToExtension } = vi.hoisted(() => ({
+  mockDispatchToExtension:
+    vi.fn<(state: unknown, method: string, params: Record<string, unknown>) => Promise<unknown>>(),
+}));
 
-const createMockWs = (): WsHandle & { sent: string[] } => ({
-  sent: [] as string[],
-  send(msg: string) {
-    this.sent.push(msg);
-  },
-  close() {},
+vi.mock('../extension-protocol.js', () => ({
+  dispatchToExtension: mockDispatchToExtension,
+}));
+
+const { screenshotTab } = await import('./screenshot-tab.js');
+const { createState } = await import('../state.js');
+
+describe('screenshotTab.formatResult', () => {
+  test('emits a single MCP image content part with mimeType image/png', () => {
+    expect(screenshotTab.formatResult).toBeDefined();
+    const formatted = screenshotTab.formatResult?.({ image: 'iVBORw0KGgoAAAANSUhEUg==' });
+    expect(formatted).toEqual([{ type: 'image', data: 'iVBORw0KGgoAAAANSUhEUg==', mimeType: 'image/png' }]);
+  });
+
+  test('renders a {savedTo, bytes} summary as a text part', () => {
+    const formatted = screenshotTab.formatResult?.({ savedTo: '/tmp/shot.png', bytes: 1234 });
+    expect(formatted).toHaveLength(1);
+    const part = formatted?.[0];
+    expect(part?.type).toBe('text');
+    const text = part?.type === 'text' ? part.text : '';
+    expect(text).toContain('/tmp/shot.png');
+    expect(text).toContain('1234');
+  });
+
+  test('throws a metadata-only error when the payload is not {image: string}', () => {
+    // Contract: the error describes the malformed payload by type and keys,
+    // never by serialising the payload itself — screenshots can carry PII
+    // (tokens, DOM content) if something has gone very wrong upstream.
+    expect(() => screenshotTab.formatResult?.({ image: 12345, secret: 'leakme' })).toThrow(
+      /browser_screenshot_tab: extension returned unexpected payload/,
+    );
+    expect(() => screenshotTab.formatResult?.({ image: 12345, secret: 'leakme' })).toThrow(
+      /type=object.*keys=\[image,secret\]/,
+    );
+    expect(() => screenshotTab.formatResult?.({ image: 12345, secret: 'leakme' })).not.toThrow(/leakme/);
+  });
+
+  test('rejects an empty-string image payload as a malformed capture', () => {
+    // An empty `image` field would otherwise pass the `typeof === 'string'` check
+    // and emit a zero-byte image content part — handing clients a "successful"
+    // response that decodes to nothing. Fail fast instead.
+    expect(() => screenshotTab.formatResult?.({ image: '' })).toThrow(
+      /browser_screenshot_tab: extension returned unexpected payload \(expected \{image: non-empty string\}/,
+    );
+  });
 });
 
-const installExtensionConnection = (state: ServerState, id = 'conn-test'): WsHandle & { sent: string[] } => {
-  const ws = createMockWs();
-  const conn: ExtensionConnection = {
-    ws,
-    connectionId: id,
-    profileLabel: id,
-    tabMapping: new Map(),
-    activeNetworkCaptures: new Set(),
-  };
-  state.extensionConnections.set(id, conn);
-  return ws;
-};
-
-const settleDispatchWith = (state: ServerState, response: unknown): void => {
-  for (const [, pending] of state.pendingDispatches) {
-    pending.resolve(response);
-    clearTimeout(pending.timerId);
-  }
-};
-
-describe('browser_screenshot_tab handler', () => {
-  let workDir: string;
-
+describe('screenshotTab.handler — filePath', () => {
+  let dir: string;
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'opentabs-screenshot-test-'));
+  });
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
   beforeEach(() => {
-    workDir = mkdtempSync(join(tmpdir(), 'screenshot-tab-test-'));
+    mockDispatchToExtension.mockReset();
   });
 
-  afterEach(() => {
-    rmSync(workDir, { recursive: true, force: true });
+  // A 1x1 transparent PNG.
+  const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+  test('without filePath the handler returns the raw {image} payload for formatResult', async () => {
+    mockDispatchToExtension.mockResolvedValue({ image: PNG_BASE64 });
+    const result = await screenshotTab.handler({ tabId: 1 }, createState());
+    expect(result).toEqual({ image: PNG_BASE64 });
   });
 
-  test('without filePath returns the dispatch result unchanged', async () => {
-    const state = createState();
-    installExtensionConnection(state);
-
-    const promise = screenshotTab.handler({ tabId: 1 }, state);
-    settleDispatchWith(state, { image: SAMPLE_PNG_BASE64 });
-
-    expect(await promise).toEqual({ image: SAMPLE_PNG_BASE64 });
+  test('with filePath the PNG is written to disk and a {savedTo, bytes} summary returned', async () => {
+    mockDispatchToExtension.mockResolvedValue({ image: PNG_BASE64 });
+    const path = join(dir, 'capture.png');
+    const result = (await screenshotTab.handler({ tabId: 1, filePath: path }, createState())) as {
+      savedTo: string;
+      bytes: number;
+    };
+    expect(result.savedTo).toBe(path);
+    const onDisk = await readFile(path);
+    expect(result.bytes).toBe(onDisk.byteLength);
+    // Verify the bytes are the decoded PNG (magic header).
+    expect(onDisk.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
   });
 
-  test('with absolute filePath writes valid PNG bytes to disk and returns {savedTo, bytes}', async () => {
-    const state = createState();
-    installExtensionConnection(state);
-    const filePath = join(workDir, 'shot.png');
-
-    const promise = screenshotTab.handler({ tabId: 1, filePath }, state);
-    settleDispatchWith(state, { image: SAMPLE_PNG_BASE64 });
-    const result = (await promise) as { savedTo: string; bytes: number };
-
-    const decoded = Buffer.from(SAMPLE_PNG_BASE64, 'base64');
-    expect(result).toEqual({ savedTo: filePath, bytes: decoded.byteLength });
-
-    const onDisk = readFileSync(filePath);
-    expect(onDisk.equals(decoded)).toBe(true);
-    expect(onDisk.subarray(0, 8).equals(PNG_MAGIC)).toBe(true);
-  });
-
-  test('with relative filePath rejects without dispatching to disk', async () => {
-    const state = createState();
-    installExtensionConnection(state);
-
-    const promise = screenshotTab.handler({ tabId: 1, filePath: 'relative/shot.png' }, state);
-    settleDispatchWith(state, { image: SAMPLE_PNG_BASE64 });
-
-    await expect(promise).rejects.toThrow(/filePath must be an absolute path/);
-  });
-
-  test('with filePath but malformed extension payload throws without writing', async () => {
-    const state = createState();
-    installExtensionConnection(state);
-    const filePath = join(workDir, 'should-not-exist.png');
-
-    const promise = screenshotTab.handler({ tabId: 1, filePath }, state);
-    settleDispatchWith(state, { unexpected: 'shape' });
-
-    await expect(promise).rejects.toThrow(/extension returned unexpected payload/);
-    expect(() => readFileSync(filePath)).toThrow(/ENOENT/);
+  test('rejects a non-absolute filePath', async () => {
+    mockDispatchToExtension.mockResolvedValue({ image: PNG_BASE64 });
+    await expect(screenshotTab.handler({ tabId: 1, filePath: 'relative.png' }, createState())).rejects.toThrow(
+      /filePath must be an absolute path/,
+    );
   });
 });

--- a/platform/mcp-server/src/browser-tools/screenshot-tab.ts
+++ b/platform/mcp-server/src/browser-tools/screenshot-tab.ts
@@ -1,5 +1,11 @@
 /**
- * browser_screenshot_tab — capture a screenshot of a browser tab as a base64-encoded PNG.
+ * browser_screenshot_tab — capture a screenshot of a browser tab as a PNG.
+ *
+ * By default the PNG is returned as an MCP image content part so clients decode
+ * it directly without parsing JSON-stringified base64. When `filePath` is given,
+ * the PNG is written to that absolute path and a `{savedTo, bytes}` text summary
+ * is returned instead — useful when the caller wants an on-disk artifact rather
+ * than an inline payload.
  */
 
 import { writeFile } from 'node:fs/promises';
@@ -11,11 +17,12 @@ import { defineBrowserTool } from './definition.js';
 const screenshotTab = defineBrowserTool({
   name: 'browser_screenshot_tab',
   description:
-    'Capture a screenshot of the visible area of a browser tab as a base64-encoded PNG image. ' +
-    'The tab is automatically focused before capture. By default returns the image as a base64 ' +
-    'string without the data URI prefix. When `filePath` is provided, the PNG bytes are written ' +
-    'to that absolute path and a `{savedTo, bytes}` summary is returned instead — useful when ' +
-    'the caller needs the screenshot as an on-disk artefact rather than an inline payload.',
+    'Capture a screenshot of the visible area of a browser tab as a PNG. The tab is ' +
+    'automatically focused before capture. By default returns an MCP image content part ' +
+    '(`{type: "image", data: <base64 PNG>, mimeType: "image/png"}`) so MCP clients decode ' +
+    'the image directly without parsing JSON-stringified base64. When `filePath` is provided, ' +
+    'the PNG bytes are written to that absolute path and a `{savedTo, bytes}` summary is ' +
+    'returned instead — useful when the caller needs the screenshot as an on-disk artifact.',
   summary: 'Capture a screenshot of a tab',
   icon: 'camera',
   group: 'Page Inspection',
@@ -30,8 +37,8 @@ const screenshotTab = defineBrowserTool({
       .optional()
       .describe(
         'Absolute path to write the captured PNG to. When set, the PNG bytes are written to this ' +
-          'path and `{savedTo: <path>, bytes: <number>}` is returned in place of the inline base64 ' +
-          'image. The parent directory must already exist; an existing file at the path is overwritten.',
+          'path and `{savedTo: <path>, bytes: <number>}` is returned in place of the inline image ' +
+          'content part. The parent directory must already exist; an existing file at the path is overwritten.',
       ),
   }),
   handler: async (args, state) => {
@@ -45,16 +52,32 @@ const screenshotTab = defineBrowserTool({
       );
     }
     const data = (result as { image?: unknown } | null)?.image;
-    if (typeof data !== 'string') {
+    if (typeof data !== 'string' || data.length === 0) {
       const payloadType = result === null ? 'null' : Array.isArray(result) ? 'array' : typeof result;
       const keys = result !== null && typeof result === 'object' && !Array.isArray(result) ? Object.keys(result) : [];
       throw new Error(
-        `browser_screenshot_tab: extension returned unexpected payload (expected {image: string}, got type=${payloadType}${keys.length > 0 ? `, keys=[${keys.join(',')}]` : ''})`,
+        `browser_screenshot_tab: extension returned unexpected payload (expected {image: non-empty string}, got type=${payloadType}${keys.length > 0 ? `, keys=[${keys.join(',')}]` : ''})`,
       );
     }
     const bytes = Buffer.from(data, 'base64');
     await writeFile(args.filePath, bytes);
     return { savedTo: args.filePath, bytes: bytes.byteLength };
+  },
+  formatResult: result => {
+    // The on-disk path: handler returned a {savedTo, bytes} summary — render as text.
+    if (result !== null && typeof result === 'object' && 'savedTo' in result) {
+      return [{ type: 'text', text: JSON.stringify(result, null, 2) }];
+    }
+    // The default path: handler returned {image} — emit a native MCP image part.
+    const data = (result as { image?: unknown } | null)?.image;
+    if (typeof data !== 'string' || data.length === 0) {
+      const payloadType = result === null ? 'null' : Array.isArray(result) ? 'array' : typeof result;
+      const keys = result !== null && typeof result === 'object' && !Array.isArray(result) ? Object.keys(result) : [];
+      throw new Error(
+        `browser_screenshot_tab: extension returned unexpected payload (expected {image: non-empty string}, got type=${payloadType}${keys.length > 0 ? `, keys=[${keys.join(',')}]` : ''})`,
+      );
+    }
+    return [{ type: 'image', data, mimeType: 'image/png' }];
   },
 });
 

--- a/platform/mcp-server/src/mcp-gateway.test.ts
+++ b/platform/mcp-server/src/mcp-gateway.test.ts
@@ -3,7 +3,22 @@ import { z } from 'zod';
 import type { BrowserToolDefinition } from './browser-tools/definition.js';
 import { annotateTools, GATEWAY_TOOLS, handleCallTool, handleListTools } from './mcp-gateway.js';
 import { PLATFORM_TOOL_NAMES, rebuildCachedBrowserTools } from './mcp-setup.js';
-import type { DispatchCallbacks, RequestHandlerExtra } from './mcp-tool-dispatch.js';
+import type { DispatchCallbacks, RequestHandlerExtra, ToolCallResult } from './mcp-tool-dispatch.js';
+
+/**
+ * Test helper: assert the content part at `idx` is text-typed and return it
+ * narrowed. handleCallTool returns a union content type since the dispatcher
+ * may emit non-text parts; gateway-level tests still expect text for errors
+ * and JSON tool output.
+ */
+const textPart = (result: ToolCallResult, idx = 0): { type: 'text'; text: string } => {
+  const part = result.content[idx];
+  if (!part || part.type !== 'text') {
+    throw new Error(`Expected text content part at index ${idx}, got: ${JSON.stringify(part)}`);
+  }
+  return part;
+};
+
 import { buildRegistry } from './registry.js';
 import type { RegisteredPlugin } from './state.js';
 import { createState } from './state.js';
@@ -236,7 +251,7 @@ describe('handleCallTool', () => {
     const result = await handleCallTool(state, {}, createMockExtra(), createMockCallbacks());
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"tool" must be a non-empty string');
+    expect(textPart(result).text).toContain('"tool" must be a non-empty string');
   });
 
   test('returns error when tool field is empty string', async () => {
@@ -245,7 +260,7 @@ describe('handleCallTool', () => {
     const result = await handleCallTool(state, { tool: '' }, createMockExtra(), createMockCallbacks());
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"tool" must be a non-empty string');
+    expect(textPart(result).text).toContain('"tool" must be a non-empty string');
   });
 
   test('returns error when tool field is not a string', async () => {
@@ -254,7 +269,7 @@ describe('handleCallTool', () => {
     const result = await handleCallTool(state, { tool: 123 }, createMockExtra(), createMockCallbacks());
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"tool" must be a non-empty string');
+    expect(textPart(result).text).toContain('"tool" must be a non-empty string');
   });
 
   test('returns error for unknown tool name', async () => {
@@ -263,7 +278,7 @@ describe('handleCallTool', () => {
     const result = await handleCallTool(state, { tool: 'nonexistent_tool' }, createMockExtra(), createMockCallbacks());
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('not found');
+    expect(textPart(result).text).toContain('not found');
   });
 
   test('routes browser tool call to browser dispatch', async () => {
@@ -286,7 +301,7 @@ describe('handleCallTool', () => {
     );
 
     expect(result.isError).toBeUndefined();
-    expect(result.content[0]?.text).toContain('browser-ok');
+    expect(textPart(result).text).toContain('browser-ok');
   });
 
   test('routes plugin tool call and returns "Extension not connected" without extension', async () => {
@@ -302,7 +317,7 @@ describe('handleCallTool', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Extension not connected');
+    expect(textPart(result).text).toContain('Extension not connected');
   });
 
   test('passes arguments through to the dispatch handler', async () => {

--- a/platform/mcp-server/src/mcp-gateway.ts
+++ b/platform/mcp-server/src/mcp-gateway.ts
@@ -12,7 +12,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { log } from './logger.js';
 import type { McpServerInstance } from './mcp-setup.js';
 import { checkToolCallable, getAllToolsList, notifyToolListChanged, PLATFORM_TOOL_NAMES } from './mcp-setup.js';
-import type { DispatchCallbacks, RequestHandlerExtra } from './mcp-tool-dispatch.js';
+import type { DispatchCallbacks, RequestHandlerExtra, ToolCallResult } from './mcp-tool-dispatch.js';
 import {
   handleBrowserToolCall,
   handlePluginInspect,
@@ -102,7 +102,7 @@ const handleCallTool = async (
   args: Record<string, unknown>,
   extra: RequestHandlerExtra,
   callbacks: DispatchCallbacks,
-): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> => {
+): Promise<ToolCallResult> => {
   const toolName = args.tool;
   if (typeof toolName !== 'string' || toolName.length === 0) {
     return {

--- a/platform/mcp-server/src/mcp-tool-dispatch.test.ts
+++ b/platform/mcp-server/src/mcp-tool-dispatch.test.ts
@@ -10,7 +10,7 @@ import {
   sendInvocationStart,
 } from './extension-protocol.js';
 import { log } from './logger.js';
-import type { DispatchCallbacks, RequestHandlerExtra } from './mcp-tool-dispatch.js';
+import type { DispatchCallbacks, RequestHandlerExtra, ToolCallResult } from './mcp-tool-dispatch.js';
 import {
   formatStructuredError,
   formatZodError,
@@ -21,6 +21,20 @@ import {
   REVIEW_GUIDANCE,
   sanitizeOutput,
 } from './mcp-tool-dispatch.js';
+
+/**
+ * Test helper: assert the content part at `idx` is text-typed and return it
+ * narrowed. Most dispatcher tests assert on text output; this avoids repeating
+ * the union-narrow pattern at every call site.
+ */
+const textPart = (result: ToolCallResult, idx = 0): { type: 'text'; text: string } => {
+  const part = result.content[idx];
+  if (!part || part.type !== 'text') {
+    throw new Error(`Expected text content part at index ${idx}, got: ${JSON.stringify(part)}`);
+  }
+  return part;
+};
+
 import type { CachedBrowserTool, RegisteredPlugin, ServerState, ToolLookupEntry } from './state.js';
 import {
   appendAuditEntry,
@@ -337,12 +351,10 @@ describe('handleBrowserToolCall', () => {
     const result = await handleBrowserToolCall(state, 'browser_test_tool', {}, bt, extra, callbacks);
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('currently disabled');
-    expect(result.content[0]?.text).toContain('In the OpenTabs side panel: toggle the tool on');
-    expect(result.content[0]?.text).toContain('opentabs config set plugin-permission.browser-tool auto');
-    expect(result.content[0]?.text).toContain(
-      'opentabs config set tool-permission.browser-tool.browser_test_tool auto',
-    );
+    expect(textPart(result).text).toContain('currently disabled');
+    expect(textPart(result).text).toContain('In the OpenTabs side panel: toggle the tool on');
+    expect(textPart(result).text).toContain('opentabs config set plugin-permission.browser-tool auto');
+    expect(textPart(result).text).toContain('opentabs config set tool-permission.browser-tool.browser_test_tool auto');
   });
 
   test('permission auto executes immediately', async () => {
@@ -371,7 +383,7 @@ describe('handleBrowserToolCall', () => {
     const result = await handleBrowserToolCall(state, 'browser_test_tool', {}, bt, extra, callbacks);
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('denied by the user');
+    expect(textPart(result).text).toContain('denied by the user');
     expect(sendConfirmationRequest).toHaveBeenCalledWith(state, 'browser_test_tool', 'browser', {});
   });
 
@@ -449,7 +461,7 @@ describe('handleBrowserToolCall', () => {
     const result = await handleBrowserToolCall(state, 'browser_test_tool', {}, bt, extra, callbacks);
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('extension is not connected');
+    expect(textPart(result).text).toContain('extension is not connected');
   });
 
   test('Zod validation failure returns isError with formatted message', async () => {
@@ -462,7 +474,7 @@ describe('handleBrowserToolCall', () => {
     const result = await handleBrowserToolCall(state, 'browser_test_tool', { url: 123 }, bt, extra, callbacks);
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Invalid arguments');
+    expect(textPart(result).text).toContain('Invalid arguments');
   });
 
   test('successful execution returns sanitized output (dangerous keys stripped)', async () => {
@@ -493,7 +505,7 @@ describe('handleBrowserToolCall', () => {
     const result = await handleBrowserToolCall(state, 'browser_test_tool', {}, bt, extra, callbacks);
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toBe('Browser tool error: tab crashed');
+    expect(textPart(result).text).toBe('Browser tool error: tab crashed');
   });
 
   test('audit entry recorded on success', async () => {
@@ -578,6 +590,23 @@ describe('handleBrowserToolCall', () => {
       false,
     );
   });
+
+  test('uses tool.formatResult when defined to emit non-text content parts', async () => {
+    vi.mocked(getToolPermission).mockReturnValue('auto');
+    const handler = vi.fn().mockResolvedValue({ image: 'AAAA' });
+    const formatResult = vi.fn().mockReturnValue([{ type: 'image' as const, data: 'AAAA', mimeType: 'image/png' }]);
+    const state = createMockState();
+    const bt = createMockBrowserTool({ schema: z.object({}), handler });
+    bt.tool.formatResult = formatResult;
+    const extra = createMockExtra();
+    const callbacks = createMockCallbacks();
+
+    const result = await handleBrowserToolCall(state, 'browser_test_tool', {}, bt, extra, callbacks);
+
+    expect(result.isError).toBeUndefined();
+    expect(formatResult).toHaveBeenCalledWith({ image: 'AAAA' });
+    expect(result.content).toEqual([{ type: 'image', data: 'AAAA', mimeType: 'image/png' }]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -615,7 +644,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    const text = result.content[0]?.text ?? '';
+    const text = textPart(result).text;
     expect(text).toContain('"testplugin" (v2.0.0) has not been reviewed yet');
     expect(text).toContain('plugin_inspect');
     expect(text).toContain('plugin_mark_reviewed');
@@ -648,7 +677,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    const text = result.content[0]?.text ?? '';
+    const text = textPart(result).text;
     expect(text).toContain('"testplugin" has been updated from v2.0.0 to v3.0.0 and needs re-review');
     expect(text).toContain('plugin_inspect');
     expect(text).toContain('plugin_mark_reviewed');
@@ -665,7 +694,7 @@ describe('handlePluginToolCall', () => {
     const result = await handleBrowserToolCall(state, 'browser_test_tool', {}, bt, extra, callbacks);
 
     expect(result.isError).toBe(true);
-    const text = result.content[0]?.text ?? '';
+    const text = textPart(result).text;
     expect(text).toContain('currently disabled');
     expect(text).not.toContain('plugin_inspect');
     expect(text).not.toContain('review');
@@ -691,7 +720,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('denied by the user');
+    expect(textPart(result).text).toContain('denied by the user');
     expect(sendConfirmationRequest).toHaveBeenCalledWith(state, 'test_action', 'testplugin', {});
   });
 
@@ -821,8 +850,8 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('has not been reviewed yet');
-    expect(result.content[0]?.text).toContain('plugin_inspect');
+    expect(textPart(result).text).toContain('has not been reviewed yet');
+    expect(textPart(result).text).toContain('plugin_inspect');
   });
 
   test('schema compilation failure (validate is null) returns error', async () => {
@@ -847,7 +876,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('schema compilation failed');
+    expect(textPart(result).text).toContain('schema compilation failed');
   });
 
   test('validator throws returns "validation failed unexpectedly"', async () => {
@@ -873,7 +902,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('validation failed unexpectedly');
+    expect(textPart(result).text).toContain('validation failed unexpectedly');
   });
 
   test('validation failure returns "Invalid arguments" with errors', async () => {
@@ -898,8 +927,8 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Invalid arguments');
-    expect(result.content[0]?.text).toContain('missing required field "channel"');
+    expect(textPart(result).text).toContain('Invalid arguments');
+    expect(textPart(result).text).toContain('missing required field "channel"');
   });
 
   test('concurrency limit exceeded returns error', async () => {
@@ -922,8 +951,8 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Too many concurrent dispatches');
-    expect(result.content[0]?.text).toContain('testplugin');
+    expect(textPart(result).text).toContain('Too many concurrent dispatches');
+    expect(textPart(result).text).toContain('testplugin');
   });
 
   test('extension not connected returns error', async () => {
@@ -945,7 +974,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Extension not connected');
+    expect(textPart(result).text).toContain('Extension not connected');
   });
 
   test('successful dispatch returns sanitized output', async () => {
@@ -968,8 +997,8 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBeUndefined();
-    expect(result.content[0]?.text).toContain('"id"');
-    expect(result.content[0]?.text).toContain('"123"');
+    expect(textPart(result).text).toContain('"id"');
+    expect(textPart(result).text).toContain('"123"');
   });
 
   test('successful dispatch sanitizes dangerous keys from output', async () => {
@@ -1044,7 +1073,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Tab closed:');
+    expect(textPart(result).text).toContain('Tab closed:');
   });
 
   test('DispatchError with code -32002 prefixes "Tab unavailable:"', async () => {
@@ -1069,7 +1098,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Tab unavailable:');
+    expect(textPart(result).text).toContain('Tab unavailable:');
   });
 
   test('DispatchError with data.code (ToolError) formats structured error', async () => {
@@ -1131,7 +1160,7 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toBe('[SOME_ERROR] something wrong');
+    expect(textPart(result).text).toBe('[SOME_ERROR] something wrong');
   });
 
   test('generic non-dispatch error returns "Tool dispatch error:" message', async () => {
@@ -1155,8 +1184,8 @@ describe('handlePluginToolCall', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Tool dispatch error:');
-    expect(result.content[0]?.text).toContain('network failure');
+    expect(textPart(result).text).toContain('Tool dispatch error:');
+    expect(textPart(result).text).toContain('network failure');
   });
 
   test('activeDispatches counter increments and decrements correctly', async () => {
@@ -1629,7 +1658,7 @@ describe('handlePluginInspect', () => {
     const result = await handlePluginInspect(state, { plugin: 'test-plugin' });
 
     expect(result.isError).toBeUndefined();
-    const parsed = JSON.parse(result.content[0]?.text ?? '') as Record<string, unknown>;
+    const parsed = JSON.parse(textPart(result).text) as Record<string, unknown>;
     expect(parsed.plugin).toBe('test-plugin');
     expect(parsed.version).toBe('1.2.3');
     expect(parsed.npmPackage).toBe('opentabs-plugin-test');
@@ -1646,8 +1675,8 @@ describe('handlePluginInspect', () => {
     const result = await handlePluginInspect(state, { plugin: 'nonexistent' });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('not found');
-    expect(result.content[0]?.text).toContain('test-plugin');
+    expect(textPart(result).text).toContain('not found');
+    expect(textPart(result).text).toContain('test-plugin');
   });
 
   test('returns error for missing plugin name', async () => {
@@ -1656,7 +1685,7 @@ describe('handlePluginInspect', () => {
     const result = await handlePluginInspect(state, {});
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('non-empty string');
+    expect(textPart(result).text).toContain('non-empty string');
   });
 
   test('returns error for empty plugin name', async () => {
@@ -1665,7 +1694,7 @@ describe('handlePluginInspect', () => {
     const result = await handlePluginInspect(state, { plugin: '' });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('non-empty string');
+    expect(textPart(result).text).toContain('non-empty string');
   });
 
   test('generates review token via generateReviewToken', async () => {
@@ -1683,7 +1712,7 @@ describe('handlePluginInspect', () => {
 
     const result = await handlePluginInspect(state, { plugin: 'test-plugin' });
 
-    const parsed = JSON.parse(result.content[0]?.text ?? '') as Record<string, unknown>;
+    const parsed = JSON.parse(textPart(result).text) as Record<string, unknown>;
     expect(typeof parsed.reviewGuidance).toBe('string');
     expect(parsed.reviewGuidance as string).toContain('Data exfiltration');
     expect(parsed.reviewGuidance as string).toContain('Code execution vectors');
@@ -1696,7 +1725,7 @@ describe('handlePluginInspect', () => {
     const result = await handlePluginInspect(state, { plugin: 'test-plugin' });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('no adapter IIFE');
+    expect(textPart(result).text).toContain('no adapter IIFE');
   });
 
   test('omits npmPackage when not set', async () => {
@@ -1705,7 +1734,7 @@ describe('handlePluginInspect', () => {
 
     const result = await handlePluginInspect(state, { plugin: 'test-plugin' });
 
-    const parsed = JSON.parse(result.content[0]?.text ?? '') as Record<string, unknown>;
+    const parsed = JSON.parse(textPart(result).text) as Record<string, unknown>;
     expect(parsed.npmPackage).toBeUndefined();
   });
 
@@ -1715,7 +1744,7 @@ describe('handlePluginInspect', () => {
 
     const result = await handlePluginInspect(state, { plugin: 'test-plugin' });
 
-    const parsed = JSON.parse(result.content[0]?.text ?? '') as Record<string, unknown>;
+    const parsed = JSON.parse(textPart(result).text) as Record<string, unknown>;
     expect(parsed.author).toBeUndefined();
   });
 });
@@ -1743,11 +1772,11 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBeUndefined();
-    expect(result.content[0]?.text).toContain('test-plugin');
-    expect(result.content[0]?.text).toContain('v1.2.3');
-    expect(result.content[0]?.text).toContain('reviewed');
-    expect(result.content[0]?.text).toContain('"auto"');
-    expect(result.content[0]?.text).toContain(
+    expect(textPart(result).text).toContain('test-plugin');
+    expect(textPart(result).text).toContain('v1.2.3');
+    expect(textPart(result).text).toContain('reviewed');
+    expect(textPart(result).text).toContain('"auto"');
+    expect(textPart(result).text).toContain(
       'Note: This tool should only be called after the user has explicitly confirmed',
     );
 
@@ -1834,8 +1863,8 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Invalid or expired review token');
-    expect(result.content[0]?.text).toContain('plugin_inspect');
+    expect(textPart(result).text).toContain('Invalid or expired review token');
+    expect(textPart(result).text).toContain('plugin_inspect');
     expect(consumeReviewToken).not.toHaveBeenCalled();
   });
 
@@ -1853,7 +1882,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Invalid or expired review token');
+    expect(textPart(result).text).toContain('Invalid or expired review token');
   });
 
   test('fails with used token', async () => {
@@ -1870,7 +1899,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Invalid or expired review token');
+    expect(textPart(result).text).toContain('Invalid or expired review token');
   });
 
   test('fails with wrong plugin', async () => {
@@ -1887,7 +1916,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Invalid or expired review token');
+    expect(textPart(result).text).toContain('Invalid or expired review token');
   });
 
   test('fails with wrong version', async () => {
@@ -1904,7 +1933,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Invalid or expired review token');
+    expect(textPart(result).text).toContain('Invalid or expired review token');
   });
 
   test('fails for unknown plugin', async () => {
@@ -1919,8 +1948,8 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('not found');
-    expect(result.content[0]?.text).toContain('test-plugin');
+    expect(textPart(result).text).toContain('not found');
+    expect(textPart(result).text).toContain('test-plugin');
   });
 
   test('fails with permission "off"', async () => {
@@ -1936,7 +1965,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"ask" or "auto"');
+    expect(textPart(result).text).toContain('"ask" or "auto"');
   });
 
   test('fails with missing plugin name', async () => {
@@ -1950,7 +1979,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"plugin" must be a non-empty string');
+    expect(textPart(result).text).toContain('"plugin" must be a non-empty string');
   });
 
   test('fails with missing version', async () => {
@@ -1964,7 +1993,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"version" must be a non-empty string');
+    expect(textPart(result).text).toContain('"version" must be a non-empty string');
   });
 
   test('fails with missing reviewToken', async () => {
@@ -1978,7 +2007,7 @@ describe('handlePluginMarkReviewed', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"reviewToken" must be a non-empty string');
+    expect(textPart(result).text).toContain('"reviewToken" must be a non-empty string');
   });
 
   test('sets permission to "ask" when requested', async () => {
@@ -1996,7 +2025,7 @@ describe('handlePluginMarkReviewed', () => {
     expect(result.isError).toBeUndefined();
     expect(state.pluginPermissions['test-plugin']?.permission).toBe('ask');
     expect(state.pluginPermissions['test-plugin']?.reviewedVersion).toBe('1.2.3');
-    expect(result.content[0]?.text).toContain('"ask"');
+    expect(textPart(result).text).toContain('"ask"');
   });
 
   test('preserves existing per-tool permission overrides', async () => {
@@ -2168,8 +2197,8 @@ describe('handlePluginToolCall — instance parameter', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('No open tab found for instance "staging"');
-    expect(result.content[0]?.text).toContain('staging');
+    expect(textPart(result).text).toContain('No open tab found for instance "staging"');
+    expect(textPart(result).text).toContain('staging');
   });
 
   test('unknown instance returns error listing valid instances', async () => {
@@ -2208,9 +2237,9 @@ describe('handlePluginToolCall — instance parameter', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('Unknown instance "nonexistent"');
-    expect(result.content[0]?.text).toContain('production');
-    expect(result.content[0]?.text).toContain('staging');
+    expect(textPart(result).text).toContain('Unknown instance "nonexistent"');
+    expect(textPart(result).text).toContain('production');
+    expect(textPart(result).text).toContain('staging');
   });
 
   test('tabId takes precedence over instance', async () => {
@@ -2492,7 +2521,7 @@ describe('handlePluginToolCall — instance parameter', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('No open tab found for instance "alpha"');
+    expect(textPart(result).text).toContain('No open tab found for instance "alpha"');
   });
 });
 

--- a/platform/mcp-server/src/mcp-tool-dispatch.ts
+++ b/platform/mcp-server/src/mcp-tool-dispatch.ts
@@ -10,6 +10,7 @@ import { readFile } from 'node:fs/promises';
 import type { PluginPermissionConfig, ToolPermission } from '@opentabs-dev/shared';
 import { toErrorMessage } from '@opentabs-dev/shared';
 import type { ZodError } from 'zod';
+import type { ToolContentPart } from './browser-tools/definition.js';
 import { savePluginPermissions } from './config.js';
 import { buildConfigStatePayload, sendToExtension } from './extension-handlers.js';
 import {
@@ -151,7 +152,7 @@ const formatZodError = (err: ZodError): string => {
 
 /** Result shape returned by both handleBrowserToolCall and handlePluginToolCall */
 interface ToolCallResult {
-  content: Array<{ type: 'text'; text: string }>;
+  content: ToolContentPart[];
   isError?: boolean;
 }
 
@@ -288,9 +289,10 @@ const handleBrowserToolCall = async (
   try {
     const result = await cachedBt.tool.handler(parseResult.data, state);
     const cleaned = sanitizeOutput(result);
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(cleaned, null, 2) }],
-    };
+    const content = cachedBt.tool.formatResult
+      ? cachedBt.tool.formatResult(cleaned)
+      : [{ type: 'text' as const, text: JSON.stringify(cleaned, null, 2) }];
+    return { content };
   } catch (err) {
     btSuccess = false;
     const msg = toErrorMessage(err);

--- a/platform/shared/src/generated/browser-tools-catalog.ts
+++ b/platform/shared/src/generated/browser-tools-catalog.ts
@@ -447,7 +447,7 @@ export const BROWSER_TOOLS_CATALOG: readonly BrowserToolMeta[] = [
   {
     name: 'browser_screenshot_tab',
     description:
-      'Capture a screenshot of the visible area of a browser tab as a base64-encoded PNG image. The tab is automatically focused before capture. By default returns the image as a base64 string without the data URI prefix. When `filePath` is provided, the PNG bytes are written to that absolute path and a `{savedTo, bytes}` summary is returned instead — useful when the caller needs the screenshot as an on-disk artefact rather than an inline payload.',
+      'Capture a screenshot of the visible area of a browser tab as a PNG. The tab is automatically focused before capture. By default returns an MCP image content part (`{type: "image", data: <base64 PNG>, mimeType: "image/png"}`) so MCP clients decode the image directly without parsing JSON-stringified base64. When `filePath` is provided, the PNG bytes are written to that absolute path and a `{savedTo, bytes}` summary is returned instead — useful when the caller needs the screenshot as an on-disk artifact.',
     summary: 'Capture a screenshot of a tab',
     icon: 'camera',
     group: 'Page Inspection',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['platform/**/*.test.ts'],
+    include: ['platform/**/*.test.ts', 'e2e/**/*.test.ts'],
     globals: false,
     testTimeout: 30_000,
   },


### PR DESCRIPTION
Supersedes #62. This is the narrow, rebased version — only the screenshot work, no fork-personal files, no unrelated tab-groups commits.

## Summary

`browser_screenshot_tab` previously returned its base64 PNG as JSON inside a `text` content part. Small results arrived inline as `[{type:'text', text:'{\"image\":...}'}]`; large results were spilled by Claude Code (and likely other MCP clients) to a tool-result file containing only the parsed inner JSON — no content-array wrapper. Callers had to branch on the input type.

The fix emits a proper MCP `image` content part (`{type:'image', data:'<base64>', mimeType:'image/png'}`). MCP clients decode image content parts natively regardless of size, so the text-spill path is bypassed entirely and consumer parse paths become uniform.

## Implementation

- `BrowserToolDefinition` gains an optional `formatResult?: (result) => ToolContentPart[]` hook. The dispatcher uses it when defined; otherwise it falls back to the existing JSON-stringify-as-text wrapping. Zero-risk extension point for any future binary-returning tool.
- `browser_screenshot_tab` ships its own `formatResult` that transforms the extension's `{image: <base64>}` into the single-part image array. The runtime guard error message describes the payload by type and keys only — never by content — so incidental PII in any drifted payload shape cannot leak via the error.
- `ToolCallResult.content` is widened from `Array<{type:'text', text:string}>` to `ToolContentPart[]` (text | image). Tests move onto a small `textPart` narrow-helper.
- Tool description, `BROWSER_TOOLS_CATALOG`, and the docs entry updated.
- `platform/cli/src/commands/tool.ts` renders image parts (writes to `os.tmpdir()`, reports path + mimeType + approximate bytes) instead of silently dropping them. The file write is wrapped so a full-disk tmpdir produces a readable error rather than a crash. Unsupported or malformed parts are reported inline.

No behaviour change for any tool other than `browser_screenshot_tab`.

## Changes from #62

- Rebased onto `upstream/main` (was conflicting against fork-main state).
- Dropped the unrelated tab-groups work — that will be a separate PR.
- Dropped fork-personal `README-HOWTO-UPDATEFORK-TO-MYSTREAM.md` and `.gitignore docs/superpowers/` entry.
- Tightened the `formatResult` error to type + keys only (no payload serialisation).
- Added a malformed-payload unit test asserting the error carries no payload content.
- Wrapped `saveImage`'s `writeFileSync` with a readable error.

## Test plan

- [x] `tsc --build` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run knip` clean
- [x] `npm run generate:browser-tools-catalog` reports up-to-date
- [x] 2027 unit tests pass across mcp-server, shared, and cli packages
- [x] New unit test: `handleBrowserToolCall` routes through `formatResult` when a tool defines it
- [x] New unit test: `screenshotTab.formatResult` emits a single-part `image/png` content block
- [x] New unit test: `screenshotTab.formatResult` error message describes malformed payload by type/keys only, no payload content
- [x] 5 new unit tests for CLI `renderToolCallContent` (text-only, image-only, mixed, unsupported type, malformed image)
- [x] Live end-to-end: rebuilt the server, restarted the daemon, called `browser_screenshot_tab` via a raw HTTP MCP client. Response was `{content: [{type:'image', mimeType:'image/png', data:<valid-PNG-base64>}]}`; PNG magic bytes `89504e470d0a1a0a` confirmed; no `isError`.

[Cld]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can return heterogeneous content parts (including images); CLI renders mixed content, saves image parts to files, and shows MIME and saved path; test client surfaces raw contentParts alongside joined text.
* **Bug Fixes**
  * Malformed or unsupported tool result parts are explicitly reported; image write failures produce descriptive errors.
* **Documentation**
  * Browser screenshot docs updated to reflect image content-part output.
* **Tests**
  * Expanded unit and e2e tests for mixed content, image handling, malformed inputs, and format validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->