### PR TITLE
fix(slack): use V1 files.upload API to avoid CORS failure

### DIFF
--- a/plugins/slack/src/slack-api.ts
+++ b/plugins/slack/src/slack-api.ts
@@ -508,4 +508,4 @@ const slackApi = async <T extends Record<string, unknown>>(
   return data as T & { ok: true };
 };
 
-export { isSlackAuthenticated, waitForSlackAuth, slackApi };
+export { getAuth, isSlackAuthenticated, waitForSlackAuth, slackApi };

--- a/plugins/slack/src/tools/upload-file.ts
+++ b/plugins/slack/src/tools/upload-file.ts
@@ -1,5 +1,5 @@
 import { getAuth } from '../slack-api.js';
-import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
+import { ToolError, defineTool, parseRetryAfterMs } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 
 export const uploadFile = defineTool({
@@ -73,10 +73,7 @@ export const uploadFile = defineTool({
       }
     }
 
-    // Use the V1 files.upload API via a same-origin multipart form POST.
-    // The V2 flow (getUploadURLExternal + fetch to files.slack.com +
-    // completeUploadExternal) fails because the adapter runs in MAIN world
-    // and the upload URL is on a different origin, blocked by CORS.
+    // V1 files.upload: same-origin multipart form POST via getAuth() credentials.
     const auth = getAuth();
     if (!auth) {
       throw ToolError.auth('Not authenticated — no Slack session token found');
@@ -128,12 +125,24 @@ export const uploadFile = defineTool({
     }
 
     if (response.status === 429) {
-      throw ToolError.rateLimited('Slack API rate limited (429) during file upload');
+      const retryAfterHeader = response.headers.get('Retry-After');
+      const retryMs = retryAfterHeader !== null ? parseRetryAfterMs(retryAfterHeader) : undefined;
+      throw ToolError.rateLimited(
+        `Slack API rate limited (429) during file upload${retryAfterHeader ? `. Retry after ${retryAfterHeader} seconds` : ''}`,
+        retryMs,
+      );
     }
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => response.statusText);
-      throw ToolError.internal(`File upload HTTP ${response.status}: ${errorText}`);
+      const errorMsg = `File upload HTTP ${response.status}: ${errorText}`;
+      if (response.status === 401 || response.status === 403) {
+        throw ToolError.auth(errorMsg);
+      } else if (response.status === 404) {
+        throw ToolError.notFound(errorMsg);
+      } else {
+        throw ToolError.internal(errorMsg);
+      }
     }
 
     let data: Record<string, unknown>;
@@ -145,11 +154,29 @@ export const uploadFile = defineTool({
 
     if (data.ok !== true) {
       const error = typeof data.error === 'string' ? data.error : 'unknown_error';
-      throw ToolError.internal(`Slack API error during file upload: ${error}`);
+      if (
+        ['not_authed', 'invalid_auth', 'account_inactive', 'token_revoked', 'token_expired', 'missing_scope'].includes(
+          error,
+        )
+      ) {
+        throw ToolError.auth(`Slack API error: ${error}`);
+      } else if (['channel_not_found', 'not_in_channel'].includes(error)) {
+        throw ToolError.notFound(`Slack API error: ${error}`);
+      } else if (error === 'ratelimited') {
+        throw ToolError.rateLimited(`Slack API error: ${error}`);
+      } else if (['invalid_arguments', 'too_many_attachments'].includes(error)) {
+        throw ToolError.validation(`Slack API error: ${error}`);
+      } else {
+        throw ToolError.internal(`Slack API error: ${error}`);
+      }
     }
 
-    const file = data.file as Record<string, unknown> | undefined;
-    const fileId = typeof file?.id === 'string' ? file.id : '';
+    const file =
+      typeof data.file === 'object' && data.file !== null ? (data.file as Record<string, unknown>) : undefined;
+    if (typeof file?.id !== 'string' || file.id.length === 0) {
+      throw ToolError.internal('Slack files.upload response missing file.id');
+    }
+    const fileId = file.id;
     const fileTitle = params.title ?? params.filename;
 
     return {

--- a/plugins/slack/src/tools/upload-file.ts
+++ b/plugins/slack/src/tools/upload-file.ts
@@ -1,4 +1,4 @@
-import { slackApi } from '../slack-api.js';
+import { getAuth } from '../slack-api.js';
 import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 
@@ -73,43 +73,51 @@ export const uploadFile = defineTool({
       }
     }
 
-    const uploadResponse = await slackApi<{
-      upload_url?: string;
-      file_id?: string;
-    }>('files.getUploadURLExternal', {
-      filename: params.filename,
-      length: contentBytes.byteLength,
-      ...(params.filetype ? { filetype: params.filetype } : {}),
-    });
-
-    if (!uploadResponse.upload_url || !uploadResponse.file_id) {
-      throw ToolError.internal('Failed to obtain upload URL from Slack');
+    // Use the V1 files.upload API via a same-origin multipart form POST.
+    // The V2 flow (getUploadURLExternal + fetch to files.slack.com +
+    // completeUploadExternal) fails because the adapter runs in MAIN world
+    // and the upload URL is on a different origin, blocked by CORS.
+    const auth = getAuth();
+    if (!auth) {
+      throw ToolError.auth('Not authenticated — no Slack session token found');
     }
 
-    const uploadUrl = new URL(uploadResponse.upload_url);
-    if (uploadUrl.protocol !== 'https:') {
-      throw ToolError.validation('Upload URL must use HTTPS');
-    }
-    const SLACK_DOMAINS = ['slack.com', 'slack-edge.com'];
-    if (!SLACK_DOMAINS.some(d => uploadUrl.hostname === d || uploadUrl.hostname.endsWith(`.${d}`))) {
-      throw ToolError.validation('Upload URL domain is not a trusted Slack domain');
+    if (!auth.workspaceUrl.startsWith('https://')) {
+      throw ToolError.validation('HTTPS required for Slack API calls');
     }
 
-    const uploadSignal = AbortSignal.timeout(30_000);
-    let uploadResult: Response;
+    const formData = new FormData();
+    formData.append('token', auth.token);
+    formData.append('channels', params.channel);
+    formData.append('filename', params.filename);
+
+    const fileBlob = new Blob([contentBytes]);
+    formData.append('file', fileBlob, params.filename);
+
+    if (params.title) {
+      formData.append('title', params.title);
+    }
+    if (params.initial_comment) {
+      formData.append('initial_comment', params.initial_comment);
+    }
+    if (params.filetype) {
+      formData.append('filetype', params.filetype);
+    }
+
+    const signal = AbortSignal.timeout(30_000);
+    let response: Response;
     try {
-      uploadResult = await fetch(uploadResponse.upload_url, {
+      response = await fetch(`${auth.workspaceUrl}/api/files.upload`, {
         method: 'POST',
-        body: contentBytes,
+        body: formData,
         credentials: 'include',
-        redirect: 'error',
-        signal: uploadSignal,
+        signal,
       });
     } catch (error) {
       if (error instanceof DOMException && error.name === 'TimeoutError') {
         throw ToolError.timeout('upload-file: file upload timed out after 30000ms');
       }
-      if (uploadSignal.aborted) {
+      if (signal.aborted) {
         throw new ToolError('upload-file: file upload aborted', 'aborted');
       }
       throw new ToolError(
@@ -118,21 +126,35 @@ export const uploadFile = defineTool({
         { category: 'internal', retryable: true },
       );
     }
-    if (!uploadResult.ok) {
-      throw ToolError.internal(`File upload HTTP ${uploadResult.status}`);
+
+    if (response.status === 429) {
+      throw ToolError.rateLimited('Slack API rate limited (429) during file upload');
     }
 
-    const fileTitle = params.title ?? params.filename;
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => response.statusText);
+      throw ToolError.internal(`File upload HTTP ${response.status}: ${errorText}`);
+    }
 
-    await slackApi('files.completeUploadExternal', {
-      files: [{ id: uploadResponse.file_id, title: fileTitle }],
-      channel_id: params.channel,
-      initial_comment: params.initial_comment,
-    });
+    let data: Record<string, unknown>;
+    try {
+      data = (await response.json()) as Record<string, unknown>;
+    } catch {
+      throw ToolError.internal('Failed to parse file upload response');
+    }
+
+    if (data.ok !== true) {
+      const error = typeof data.error === 'string' ? data.error : 'unknown_error';
+      throw ToolError.internal(`Slack API error during file upload: ${error}`);
+    }
+
+    const file = data.file as Record<string, unknown> | undefined;
+    const fileId = typeof file?.id === 'string' ? file.id : '';
+    const fileTitle = params.title ?? params.filename;
 
     return {
       file: {
-        id: uploadResponse.file_id,
+        id: fileId,
         title: fileTitle,
       },
     };

--- a/plugins/slack/src/tools/upload-file.ts
+++ b/plugins/slack/src/tools/upload-file.ts
@@ -127,10 +127,8 @@ export const uploadFile = defineTool({
     if (response.status === 429) {
       const retryAfterHeader = response.headers.get('Retry-After');
       const retryMs = retryAfterHeader !== null ? parseRetryAfterMs(retryAfterHeader) : undefined;
-      throw ToolError.rateLimited(
-        `Slack API rate limited (429) during file upload${retryAfterHeader ? `. Retry after ${retryAfterHeader} seconds` : ''}`,
-        retryMs,
-      );
+      const retryHint = retryMs !== undefined ? `. Retry after ${Math.ceil(retryMs / 1000)}s` : '';
+      throw ToolError.rateLimited(`Slack API rate limited (429) during file upload${retryHint}`, retryMs);
     }
 
     if (!response.ok) {
@@ -140,6 +138,8 @@ export const uploadFile = defineTool({
         throw ToolError.auth(errorMsg);
       } else if (response.status === 404) {
         throw ToolError.notFound(errorMsg);
+      } else if (response.status === 400) {
+        throw ToolError.validation(errorMsg);
       } else {
         throw ToolError.internal(errorMsg);
       }


### PR DESCRIPTION
## Summary

`slack_upload_file` fails on every call with `Failed to fetch`. The V2 upload API needs a cross-origin fetch to `files.slack.com`, which the browser blocks because the adapter runs in MAIN world on `app.slack.com`.

This switches to Slack's V1 `files.upload` API, posting the file content as a multipart form to the same-origin `/api/files.upload` endpoint. Every other Slack tool already uses same-origin requests through `slackApi()`. This brings file uploads in line.

### What changed

- **`plugins/slack/src/tools/upload-file.ts`**: Replaced the three-step V2 upload flow with a single multipart form POST to `files.upload` (V1). Added rate-limit handling and response parsing for the V1 response shape.
- **`plugins/slack/src/slack-api.ts`**: Exported `getAuth()` so the upload tool can build its own authenticated multipart request.

### Trade-offs

The V1 `files.upload` API is deprecated by Slack but still works. The V2 API can't work from MAIN world without SDK-level support for routing fetches through the background service worker (which has `<all_urls>` privileges). A `backgroundFetch` SDK primitive would be the proper long-term fix, but this unblocks file uploads now.

Fixes #67

## Test plan

- [ ] Upload a text file to a DM channel
- [ ] Upload a text file to a public channel
- [ ] Upload a base64-encoded image to a channel
- [ ] Confirm blocked extensions (.exe, .sh, etc.) still reject
- [ ] Confirm other Slack tools still work (send_message, read_messages, list_files, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Slack authentication support for integrations, enabling smoother sign-in and workspace linkage.

* **Bug Fixes**
  * More reliable Slack file uploads with better handling of missing auth, timeouts, rate limits, invalid responses, and detailed error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->