### PR TITLE
fix(ci): run docs check on every PR, not just docs changes

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths: ['docs/**']
   pull_request:
-    paths: ['docs/**']
 
 concurrency:
   group: ci-docs-${{ github.ref }}


### PR DESCRIPTION
## Summary

- The `check-docs` job is listed as a required status check in the main branch ruleset, but its workflow was path-filtered to only trigger when `docs/**` changed.
- Every non-docs PR therefore got stuck in `mergeable_state: blocked` because a required status context never reported — forcing admin-override merges.
- Remove the path filter on the `pull_request` trigger so the job runs on every PR and satisfies the required check. The `push` trigger keeps its filter since running on main adds no value (the job already ran on the PR).

## Context

Observed on #68. The Slack file upload fix passed every check that ran (`check`, `plugins`, `e2e`, `windows`, `windows-e2e`, `CodeQL`) but couldn't merge because `check-docs` was a required context with no corresponding run. Admin-merged as a one-off.

## Test plan

- [x] This PR is itself the test — it triggers `check-docs` despite touching no files under `docs/**`, demonstrating the fix.
- [x] Docs check runs in ~1 minute historically, so the added overhead on non-docs PRs is negligible.
- [x] Push trigger still path-filtered to `docs/**` to avoid redundant runs on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to expand when documentation-related checks are triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->