### PR TITLE
deps: bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -52,6 +52,6 @@
     "knip": "^6.0.1",
     "postcss": "^8",
     "tailwindcss": "^4.0.14",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   }
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/knip.ts
+++ b/knip.ts
@@ -37,6 +37,7 @@ const config: KnipConfig = {
         'src/**/*.test.ts',
         'src/**/*.stories.tsx',
         'esbuild-plugin-babel.d.ts',
+        '.storybook/globals.d.ts',
       ],
       ignoreDependencies: [
         // Required at runtime by rolldown-vite (aliased as "vite") for Storybook builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -777,6 +777,31 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "minimatch": "^10.2.4",
         "tailwindcss": "^4.2.4",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "npm:rolldown-vite@^7.3.1",
         "vitest": "^4.1.5",
         "ws": "^8.20.0"
@@ -775,31 +775,6 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -8734,9 +8709,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "minimatch": "^10.2.4",
     "tailwindcss": "^4.2.4",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "npm:rolldown-vite@^7.3.1",
     "vitest": "^4.1.5",
     "ws": "^8.20.0"

--- a/platform/browser-extension/.storybook/globals.d.ts
+++ b/platform/browser-extension/.storybook/globals.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/plugins/airbnb/package-lock.json
+++ b/plugins/airbnb/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/airbnb/package.json
+++ b/plugins/airbnb/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/airtable/package-lock.json
+++ b/plugins/airtable/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/airtable/package.json
+++ b/plugins/airtable/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/amplitude/package-lock.json
+++ b/plugins/amplitude/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/amplitude/package.json
+++ b/plugins/amplitude/package.json
@@ -57,7 +57,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/asana/package-lock.json
+++ b/plugins/asana/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/asana/package.json
+++ b/plugins/asana/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/aws-console/package-lock.json
+++ b/plugins/aws-console/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/aws-console/package.json
+++ b/plugins/aws-console/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/azure/package-lock.json
+++ b/plugins/azure/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/azure/package.json
+++ b/plugins/azure/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/bestbuy/package-lock.json
+++ b/plugins/bestbuy/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/bestbuy/package.json
+++ b/plugins/bestbuy/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/bitbucket/package-lock.json
+++ b/plugins/bitbucket/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/bitbucket/package.json
+++ b/plugins/bitbucket/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/bluesky/package-lock.json
+++ b/plugins/bluesky/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/bluesky/package.json
+++ b/plugins/bluesky/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/booking/package-lock.json
+++ b/plugins/booking/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/booking/package.json
+++ b/plugins/booking/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/calendly/package-lock.json
+++ b/plugins/calendly/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/calendly/package.json
+++ b/plugins/calendly/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/carta/package-lock.json
+++ b/plugins/carta/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/carta/package.json
+++ b/plugins/carta/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/chatgpt/package-lock.json
+++ b/plugins/chatgpt/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/chatgpt/package.json
+++ b/plugins/chatgpt/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/chipotle/package-lock.json
+++ b/plugins/chipotle/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/chipotle/package.json
+++ b/plugins/chipotle/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/circleci/package-lock.json
+++ b/plugins/circleci/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/claude/package-lock.json
+++ b/plugins/claude/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/claude/package.json
+++ b/plugins/claude/package.json
@@ -57,7 +57,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/clickhouse/package-lock.json
+++ b/plugins/clickhouse/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/clickhouse/package.json
+++ b/plugins/clickhouse/package.json
@@ -53,7 +53,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "license": "MIT",

--- a/plugins/clickup/package-lock.json
+++ b/plugins/clickup/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/clickup/package.json
+++ b/plugins/clickup/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/clickup/src/clickup-api.ts
+++ b/plugins/clickup/src/clickup-api.ts
@@ -43,7 +43,7 @@ const installWsInterceptor = (): void => {
   g.__cu_ws_interceptor_installed = true;
 
   const OrigSend = WebSocket.prototype.send;
-  WebSocket.prototype.send = function (data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+  WebSocket.prototype.send = function (data: string | Blob | BufferSource) {
     if (typeof data === 'string') {
       try {
         const parsed = JSON.parse(data) as { method?: string; token?: string; teamId?: string };

--- a/plugins/cloudflare/package-lock.json
+++ b/plugins/cloudflare/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/cloudflare/package.json
+++ b/plugins/cloudflare/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/cockroachdb/package-lock.json
+++ b/plugins/cockroachdb/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/cockroachdb/package.json
+++ b/plugins/cockroachdb/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/coinbase/package-lock.json
+++ b/plugins/coinbase/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/coinbase/package.json
+++ b/plugins/coinbase/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/confluence/package-lock.json
+++ b/plugins/confluence/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/confluence/package.json
+++ b/plugins/confluence/package.json
@@ -64,7 +64,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/costco/package-lock.json
+++ b/plugins/costco/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/costco/package.json
+++ b/plugins/costco/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/craigslist/package-lock.json
+++ b/plugins/craigslist/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/craigslist/package.json
+++ b/plugins/craigslist/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "license": "MIT",

--- a/plugins/datadog/package-lock.json
+++ b/plugins/datadog/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/datadog/package.json
+++ b/plugins/datadog/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   }
 }

--- a/plugins/discord/package-lock.json
+++ b/plugins/discord/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/discord/package.json
+++ b/plugins/discord/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/docker-hub/package-lock.json
+++ b/plugins/docker-hub/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/docker-hub/package.json
+++ b/plugins/docker-hub/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/dominos/package-lock.json
+++ b/plugins/dominos/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/dominos/package.json
+++ b/plugins/dominos/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/doordash/package-lock.json
+++ b/plugins/doordash/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/doordash/package.json
+++ b/plugins/doordash/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/e2e-test/package-lock.json
+++ b/plugins/e2e-test/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/e2e-test/package.json
+++ b/plugins/e2e-test/package.json
@@ -64,7 +64,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/ebay/package-lock.json
+++ b/plugins/ebay/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/ebay/package.json
+++ b/plugins/ebay/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/excel-online/package-lock.json
+++ b/plugins/excel-online/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/excel-online/package.json
+++ b/plugins/excel-online/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/expedia/package-lock.json
+++ b/plugins/expedia/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/expedia/package.json
+++ b/plugins/expedia/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/facebook/package.json
+++ b/plugins/facebook/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/fidelity/package-lock.json
+++ b/plugins/fidelity/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/fidelity/package.json
+++ b/plugins/fidelity/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/figma/package-lock.json
+++ b/plugins/figma/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/figma/package.json
+++ b/plugins/figma/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/gemini/package-lock.json
+++ b/plugins/gemini/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/gemini/package.json
+++ b/plugins/gemini/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/github/package-lock.json
+++ b/plugins/github/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/gitlab/package-lock.json
+++ b/plugins/gitlab/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -65,7 +65,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/glama/package-lock.json
+++ b/plugins/glama/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/glama/package.json
+++ b/plugins/glama/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/google-analytics/package-lock.json
+++ b/plugins/google-analytics/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/google-analytics/package.json
+++ b/plugins/google-analytics/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/google-calendar/package-lock.json
+++ b/plugins/google-calendar/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/google-calendar/package.json
+++ b/plugins/google-calendar/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/google-cloud/package-lock.json
+++ b/plugins/google-cloud/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/google-cloud/package.json
+++ b/plugins/google-cloud/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/google-docs/package-lock.json
+++ b/plugins/google-docs/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/google-docs/package.json
+++ b/plugins/google-docs/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/google-drive/package-lock.json
+++ b/plugins/google-drive/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/google-drive/package.json
+++ b/plugins/google-drive/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/google-maps/package-lock.json
+++ b/plugins/google-maps/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/google-maps/package.json
+++ b/plugins/google-maps/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/grafana/package-lock.json
+++ b/plugins/grafana/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/grafana/package.json
+++ b/plugins/grafana/package.json
@@ -62,7 +62,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/hackernews/package-lock.json
+++ b/plugins/hackernews/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/hackernews/package.json
+++ b/plugins/hackernews/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/homedepot/package-lock.json
+++ b/plugins/homedepot/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/homedepot/package.json
+++ b/plugins/homedepot/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/instacart/package-lock.json
+++ b/plugins/instacart/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/instacart/package.json
+++ b/plugins/instacart/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/instagram/package-lock.json
+++ b/plugins/instagram/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/instagram/package.json
+++ b/plugins/instagram/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/jira/package-lock.json
+++ b/plugins/jira/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/jira/package.json
+++ b/plugins/jira/package.json
@@ -67,7 +67,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/leetcode/package-lock.json
+++ b/plugins/leetcode/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/leetcode/package.json
+++ b/plugins/leetcode/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/linear/package-lock.json
+++ b/plugins/linear/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/linear/package.json
+++ b/plugins/linear/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/linkedin/package-lock.json
+++ b/plugins/linkedin/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/linkedin/package.json
+++ b/plugins/linkedin/package.json
@@ -52,7 +52,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "license": "MIT",

--- a/plugins/lucid/package-lock.json
+++ b/plugins/lucid/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/lucid/package.json
+++ b/plugins/lucid/package.json
@@ -49,7 +49,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   }
 }

--- a/plugins/medium/package-lock.json
+++ b/plugins/medium/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/medium/package.json
+++ b/plugins/medium/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/meticulous/package-lock.json
+++ b/plugins/meticulous/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/meticulous/package.json
+++ b/plugins/meticulous/package.json
@@ -54,7 +54,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/microsoft-word/package-lock.json
+++ b/plugins/microsoft-word/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/microsoft-word/package.json
+++ b/plugins/microsoft-word/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/minimax-agent/package-lock.json
+++ b/plugins/minimax-agent/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/minimax-agent/package.json
+++ b/plugins/minimax-agent/package.json
@@ -57,7 +57,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/mongodb-atlas/package-lock.json
+++ b/plugins/mongodb-atlas/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/mongodb-atlas/package.json
+++ b/plugins/mongodb-atlas/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/netflix/package-lock.json
+++ b/plugins/netflix/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/netflix/package.json
+++ b/plugins/netflix/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/netlify/package-lock.json
+++ b/plugins/netlify/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/netlify/package.json
+++ b/plugins/netlify/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/newrelic/package-lock.json
+++ b/plugins/newrelic/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/newrelic/package.json
+++ b/plugins/newrelic/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/notebooklm/package-lock.json
+++ b/plugins/notebooklm/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/notebooklm/package.json
+++ b/plugins/notebooklm/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/notion/package-lock.json
+++ b/plugins/notion/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/notion/package.json
+++ b/plugins/notion/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/npm/package-lock.json
+++ b/plugins/npm/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -55,7 +55,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/onenote/package-lock.json
+++ b/plugins/onenote/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/onenote/package.json
+++ b/plugins/onenote/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/onlyfans/package-lock.json
+++ b/plugins/onlyfans/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/onlyfans/package.json
+++ b/plugins/onlyfans/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/outlook/package-lock.json
+++ b/plugins/outlook/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "*"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/outlook/package.json
+++ b/plugins/outlook/package.json
@@ -59,7 +59,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "*"
   },
   "license": "MIT",

--- a/plugins/panda-express/package-lock.json
+++ b/plugins/panda-express/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/panda-express/package.json
+++ b/plugins/panda-express/package.json
@@ -52,7 +52,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "license": "MIT",

--- a/plugins/pinterest/package-lock.json
+++ b/plugins/pinterest/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/pinterest/package.json
+++ b/plugins/pinterest/package.json
@@ -57,7 +57,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/posthog/package-lock.json
+++ b/plugins/posthog/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/posthog/package.json
+++ b/plugins/posthog/package.json
@@ -66,7 +66,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/powerpoint/package-lock.json
+++ b/plugins/powerpoint/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/powerpoint/package.json
+++ b/plugins/powerpoint/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/prescript-test/package-lock.json
+++ b/plugins/prescript-test/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/prescript-test/package.json
+++ b/plugins/prescript-test/package.json
@@ -48,7 +48,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/priceline/package-lock.json
+++ b/plugins/priceline/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/priceline/package.json
+++ b/plugins/priceline/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/reddit/package-lock.json
+++ b/plugins/reddit/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/reddit/package.json
+++ b/plugins/reddit/package.json
@@ -58,7 +58,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/redfin/package-lock.json
+++ b/plugins/redfin/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/redfin/package.json
+++ b/plugins/redfin/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/retool/package-lock.json
+++ b/plugins/retool/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/retool/package.json
+++ b/plugins/retool/package.json
@@ -65,7 +65,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "license": "MIT",

--- a/plugins/robinhood/package-lock.json
+++ b/plugins/robinhood/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/robinhood/package.json
+++ b/plugins/robinhood/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/sentry/package-lock.json
+++ b/plugins/sentry/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -65,7 +65,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/shortcut/package-lock.json
+++ b/plugins/shortcut/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/shortcut/package.json
+++ b/plugins/shortcut/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/slack-enterprise/package-lock.json
+++ b/plugins/slack-enterprise/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/slack-enterprise/package.json
+++ b/plugins/slack-enterprise/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/slack/package-lock.json
+++ b/plugins/slack/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/slack/package.json
+++ b/plugins/slack/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/snowflake/package-lock.json
+++ b/plugins/snowflake/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/snowflake/package.json
+++ b/plugins/snowflake/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/spotify/package-lock.json
+++ b/plugins/spotify/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/spotify/package.json
+++ b/plugins/spotify/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/sqlpad/package-lock.json
+++ b/plugins/sqlpad/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/sqlpad/package.json
+++ b/plugins/sqlpad/package.json
@@ -62,7 +62,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/stackoverflow/package-lock.json
+++ b/plugins/stackoverflow/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/stackoverflow/package.json
+++ b/plugins/stackoverflow/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/starbucks/package-lock.json
+++ b/plugins/starbucks/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/starbucks/package.json
+++ b/plugins/starbucks/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/steam/package-lock.json
+++ b/plugins/steam/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/steam/package.json
+++ b/plugins/steam/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/stripe/package-lock.json
+++ b/plugins/stripe/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/stripe/package.json
+++ b/plugins/stripe/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/supabase/package-lock.json
+++ b/plugins/supabase/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/supabase/package.json
+++ b/plugins/supabase/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/target/package-lock.json
+++ b/plugins/target/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/target/package.json
+++ b/plugins/target/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/teams/package-lock.json
+++ b/plugins/teams/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/teams/package.json
+++ b/plugins/teams/package.json
@@ -57,7 +57,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/telegram/package-lock.json
+++ b/plugins/telegram/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/telegram/package.json
+++ b/plugins/telegram/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/terraform-cloud/package-lock.json
+++ b/plugins/terraform-cloud/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/terraform-cloud/package.json
+++ b/plugins/terraform-cloud/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/tiktok/package-lock.json
+++ b/plugins/tiktok/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/tiktok/package.json
+++ b/plugins/tiktok/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/tinder/package-lock.json
+++ b/plugins/tinder/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/tinder/package.json
+++ b/plugins/tinder/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/todoist/package-lock.json
+++ b/plugins/todoist/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/todoist/package.json
+++ b/plugins/todoist/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.5",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/tripadvisor/package-lock.json
+++ b/plugins/tripadvisor/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/tripadvisor/package.json
+++ b/plugins/tripadvisor/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "repository": {

--- a/plugins/tumblr/package-lock.json
+++ b/plugins/tumblr/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/tumblr/package.json
+++ b/plugins/tumblr/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/twilio/package-lock.json
+++ b/plugins/twilio/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/twilio/package.json
+++ b/plugins/twilio/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/twitch/package-lock.json
+++ b/plugins/twitch/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/twitch/package.json
+++ b/plugins/twitch/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/uber/package-lock.json
+++ b/plugins/uber/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/uber/package.json
+++ b/plugins/uber/package.json
@@ -53,7 +53,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "publishConfig": {

--- a/plugins/vercel/package-lock.json
+++ b/plugins/vercel/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/vercel/package.json
+++ b/plugins/vercel/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/walmart/package-lock.json
+++ b/plugins/walmart/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/walmart/package.json
+++ b/plugins/walmart/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/webflow/package-lock.json
+++ b/plugins/webflow/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/webflow/package.json
+++ b/plugins/webflow/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/whatsapp/package-lock.json
+++ b/plugins/whatsapp/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/whatsapp/package.json
+++ b/plugins/whatsapp/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/wikipedia/package-lock.json
+++ b/plugins/wikipedia/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/wikipedia/package.json
+++ b/plugins/wikipedia/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/x/package-lock.json
+++ b/plugins/x/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -725,9 +725,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/x/package.json
+++ b/plugins/x/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/yelp/package-lock.json
+++ b/plugins/yelp/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/yelp/package.json
+++ b/plugins/yelp/package.json
@@ -56,7 +56,7 @@
     "@biomejs/biome": "2.4.6",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/plugins/ynab/package-lock.json
+++ b/plugins/ynab/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/ynab/package.json
+++ b/plugins/ynab/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/youtube-music/package-lock.json
+++ b/plugins/youtube-music/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/youtube-music/package.json
+++ b/plugins/youtube-music/package.json
@@ -59,7 +59,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/youtube/package-lock.json
+++ b/plugins/youtube/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/youtube/package.json
+++ b/plugins/youtube/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",

--- a/plugins/zendesk/package-lock.json
+++ b/plugins/zendesk/package-lock.json
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.4.5",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.0.0"
       },
       "peerDependencies": {
@@ -735,9 +735,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/zendesk/package.json
+++ b/plugins/zendesk/package.json
@@ -52,7 +52,7 @@
     "@biomejs/biome": "2.4.5",
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.0.0"
   },
   "publishConfig": {

--- a/plugins/zillow/package-lock.json
+++ b/plugins/zillow/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "2.4.6",
         "@opentabs-dev/plugin-tools": "^0.0.104",
         "jiti": "^2.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -736,9 +736,9 @@
       "license": "ISC"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/plugins/zillow/package.json
+++ b/plugins/zillow/package.json
@@ -56,7 +56,7 @@
     "@opentabs-dev/plugin-tools": "^0.0.104",
     "@biomejs/biome": "2.4.6",
     "jiti": "^2.6.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "zod": "^4.3.6"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Upgrades TypeScript from 5.9.3 to 6.0.3 across root, docs, and all 116 plugins in lockstep.
- Replaces Dependabot #61 (which only bumped root and didn't address breaking changes).

## TS 6 breaking changes fixed
- **Side-effect CSS imports require module declarations.** `platform/browser-extension/.storybook/preview.ts` imports `./preview.css` for Storybook. Added `platform/browser-extension/.storybook/globals.d.ts` with `declare module '*.css'` and registered it as a knip entry so it isn't flagged unused.
- **`WebSocket.send` parameter type narrowed.** `ArrayBufferLike` is no longer assignable because `SharedArrayBuffer` is excluded from `BufferSource`. Updated the ClickUp WebSocket interceptor signature in `plugins/clickup/src/clickup-api.ts` to `string | Blob | BufferSource`.

## Test plan
- [x] `npm run build`
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run knip`
- [x] `npm run format:check`
- [x] `npm run test` (3788 pass, 1 skip)
- [x] `npm run check:plugins` (all 116 plugins)
- [ ] CI: check, check-docs, analyze, windows, e2e, plugins, macos, windows-e2e, CodeQL