### PR TITLE
feat(screenshot-tab): add optional filePath to persist PNG to disk

### DIFF
--- a/platform/mcp-server/src/browser-tools/screenshot-tab.test.ts
+++ b/platform/mcp-server/src/browser-tools/screenshot-tab.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WsHandle } from '@opentabs-dev/shared';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import type { ExtensionConnection, ServerState } from '../state.js';
+import { createState } from '../state.js';
+import { screenshotTab } from './screenshot-tab.js';
+
+const SAMPLE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const createMockWs = (): WsHandle & { sent: string[] } => ({
+  sent: [] as string[],
+  send(msg: string) {
+    this.sent.push(msg);
+  },
+  close() {},
+});
+
+const installExtensionConnection = (state: ServerState, id = 'conn-test'): WsHandle & { sent: string[] } => {
+  const ws = createMockWs();
+  const conn: ExtensionConnection = {
+    ws,
+    connectionId: id,
+    profileLabel: id,
+    tabMapping: new Map(),
+    activeNetworkCaptures: new Set(),
+  };
+  state.extensionConnections.set(id, conn);
+  return ws;
+};
+
+const settleDispatchWith = (state: ServerState, response: unknown): void => {
+  for (const [, pending] of state.pendingDispatches) {
+    pending.resolve(response);
+    clearTimeout(pending.timerId);
+  }
+};
+
+describe('browser_screenshot_tab handler', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'screenshot-tab-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test('without filePath returns the dispatch result unchanged', async () => {
+    const state = createState();
+    installExtensionConnection(state);
+
+    const promise = screenshotTab.handler({ tabId: 1 }, state);
+    settleDispatchWith(state, { image: SAMPLE_PNG_BASE64 });
+
+    expect(await promise).toEqual({ image: SAMPLE_PNG_BASE64 });
+  });
+
+  test('with absolute filePath writes valid PNG bytes to disk and returns {savedTo, bytes}', async () => {
+    const state = createState();
+    installExtensionConnection(state);
+    const filePath = join(workDir, 'shot.png');
+
+    const promise = screenshotTab.handler({ tabId: 1, filePath }, state);
+    settleDispatchWith(state, { image: SAMPLE_PNG_BASE64 });
+    const result = (await promise) as { savedTo: string; bytes: number };
+
+    const decoded = Buffer.from(SAMPLE_PNG_BASE64, 'base64');
+    expect(result).toEqual({ savedTo: filePath, bytes: decoded.byteLength });
+
+    const onDisk = readFileSync(filePath);
+    expect(onDisk.equals(decoded)).toBe(true);
+    expect(onDisk.subarray(0, 8).equals(PNG_MAGIC)).toBe(true);
+  });
+
+  test('with relative filePath rejects without dispatching to disk', async () => {
+    const state = createState();
+    installExtensionConnection(state);
+
+    const promise = screenshotTab.handler({ tabId: 1, filePath: 'relative/shot.png' }, state);
+    settleDispatchWith(state, { image: SAMPLE_PNG_BASE64 });
+
+    await expect(promise).rejects.toThrow(/filePath must be an absolute path/);
+  });
+
+  test('with filePath but malformed extension payload throws without writing', async () => {
+    const state = createState();
+    installExtensionConnection(state);
+    const filePath = join(workDir, 'should-not-exist.png');
+
+    const promise = screenshotTab.handler({ tabId: 1, filePath }, state);
+    settleDispatchWith(state, { unexpected: 'shape' });
+
+    await expect(promise).rejects.toThrow(/extension returned unexpected payload/);
+    expect(() => readFileSync(filePath)).toThrow(/ENOENT/);
+  });
+});

--- a/platform/mcp-server/src/browser-tools/screenshot-tab.ts
+++ b/platform/mcp-server/src/browser-tools/screenshot-tab.ts
@@ -2,6 +2,8 @@
  * browser_screenshot_tab — capture a screenshot of a browser tab as a base64-encoded PNG.
  */
 
+import { writeFile } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
 import { z } from 'zod';
 import { dispatchToExtension } from '../extension-protocol.js';
 import { defineBrowserTool } from './definition.js';
@@ -10,8 +12,10 @@ const screenshotTab = defineBrowserTool({
   name: 'browser_screenshot_tab',
   description:
     'Capture a screenshot of the visible area of a browser tab as a base64-encoded PNG image. ' +
-    'The tab is automatically focused before capture. Returns the image as a base64 string ' +
-    'without the data URI prefix.',
+    'The tab is automatically focused before capture. By default returns the image as a base64 ' +
+    'string without the data URI prefix. When `filePath` is provided, the PNG bytes are written ' +
+    'to that absolute path and a `{savedTo, bytes}` summary is returned instead — useful when ' +
+    'the caller needs the screenshot as an on-disk artefact rather than an inline payload.',
   summary: 'Capture a screenshot of a tab',
   icon: 'camera',
   group: 'Page Inspection',
@@ -21,8 +25,37 @@ const screenshotTab = defineBrowserTool({
       .int()
       .positive()
       .describe('Tab ID to screenshot — the tab will be focused automatically before capture'),
+    filePath: z
+      .string()
+      .optional()
+      .describe(
+        'Absolute path to write the captured PNG to. When set, the PNG bytes are written to this ' +
+          'path and `{savedTo: <path>, bytes: <number>}` is returned in place of the inline base64 ' +
+          'image. The parent directory must already exist; an existing file at the path is overwritten.',
+      ),
   }),
-  handler: async (args, state) => dispatchToExtension(state, 'browser.screenshotTab', { tabId: args.tabId }),
+  handler: async (args, state) => {
+    const result = await dispatchToExtension(state, 'browser.screenshotTab', { tabId: args.tabId });
+    if (args.filePath === undefined) {
+      return result;
+    }
+    if (!isAbsolute(args.filePath)) {
+      throw new Error(
+        `browser_screenshot_tab: filePath must be an absolute path (got ${JSON.stringify(args.filePath)})`,
+      );
+    }
+    const data = (result as { image?: unknown } | null)?.image;
+    if (typeof data !== 'string') {
+      const payloadType = result === null ? 'null' : Array.isArray(result) ? 'array' : typeof result;
+      const keys = result !== null && typeof result === 'object' && !Array.isArray(result) ? Object.keys(result) : [];
+      throw new Error(
+        `browser_screenshot_tab: extension returned unexpected payload (expected {image: string}, got type=${payloadType}${keys.length > 0 ? `, keys=[${keys.join(',')}]` : ''})`,
+      );
+    }
+    const bytes = Buffer.from(data, 'base64');
+    await writeFile(args.filePath, bytes);
+    return { savedTo: args.filePath, bytes: bytes.byteLength };
+  },
 });
 
 export { screenshotTab };

--- a/platform/shared/src/generated/browser-tools-catalog.ts
+++ b/platform/shared/src/generated/browser-tools-catalog.ts
@@ -447,7 +447,7 @@ export const BROWSER_TOOLS_CATALOG: readonly BrowserToolMeta[] = [
   {
     name: 'browser_screenshot_tab',
     description:
-      'Capture a screenshot of the visible area of a browser tab as a base64-encoded PNG image. The tab is automatically focused before capture. Returns the image as a base64 string without the data URI prefix.',
+      'Capture a screenshot of the visible area of a browser tab as a base64-encoded PNG image. The tab is automatically focused before capture. By default returns the image as a base64 string without the data URI prefix. When `filePath` is provided, the PNG bytes are written to that absolute path and a `{savedTo, bytes}` summary is returned instead — useful when the caller needs the screenshot as an on-disk artefact rather than an inline payload.',
     summary: 'Capture a screenshot of a tab',
     icon: 'camera',
     group: 'Page Inspection',


### PR DESCRIPTION
## Summary

Adds an optional `filePath` argument to `browser_screenshot_tab`. When set, the PNG bytes are written to that absolute path and `{savedTo, bytes}` is returned in place of the inline base64 image. Without `filePath`, behaviour is unchanged.

## Motivation

MCP clients that consume the tool over JSON-RPC can render inline base64 (or, with #66, image content parts) but cannot necessarily persist them to disk themselves. A skill that needs the screenshot as an on-disk artefact - e.g. archiving a co-parenting message thread alongside a transcribed `.md` - currently has to round the bytes through a separate write step its host environment may not expose. Letting the tool write the file directly removes that layer.

## Relationship to #66

Orthogonal. #66 changes the response shape for callers that take the inline payload; this PR adds an alternative on-disk delivery path. The two PRs touch the same file but in disjoint regions of the schema and handler, and either order of merge produces a sensible end state. This PR is targeted at `main` and does not depend on #66.

## Implementation

- `platform/mcp-server/src/browser-tools/screenshot-tab.ts`: add `filePath: z.string().optional()` to the input schema. After dispatch, if `filePath` is set: validate it is absolute (`path.isAbsolute`), assert the extension payload has a string `image` field, decode via `Buffer.from(data, 'base64')`, `writeFile` the bytes, and return `{savedTo, bytes}`. The malformed-payload error message describes the payload only by type and key names - never by serialising the value, since a corrupt screenshot payload could carry PII.
- `platform/mcp-server/src/browser-tools/screenshot-tab.test.ts` (new): four unit tests:
  1. no-filePath passthrough (existing shape preserved exactly).
  2. absolute-filePath success path - verifies the on-disk bytes match the decoded base64 and the file starts with the PNG magic `89 50 4e 47 0d 0a 1a 0a`.
  3. relative-filePath rejection.
  4. malformed-payload rejection - also asserts no file was created.
- `platform/shared/src/generated/browser-tools-catalog.ts`: regenerated to pick up the description update.

## Test plan

- [x] `tsc --build` clean.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.
- [x] `npm run knip` clean.
- [x] `npm run generate:browser-tools-catalog` reports up-to-date.
- [x] All 3792 unit tests pass (including the four new ones).
- [x] Local pre-push hook (lint + test + build) passes.

[Cld]