### PR TITLE
fix(discord): guard webpack module iteration against concurrent mutation

### DIFF
--- a/plugins/discord/src/discord-api.ts
+++ b/plugins/discord/src/discord-api.ts
@@ -31,15 +31,29 @@ const getTokenFromWebpack = (): string | null => {
       [Symbol()],
       {},
       (require: { c: Record<string, { exports?: Record<string, unknown> }> }) => {
-        for (const mod of Object.values(require.c)) {
-          const exports = mod?.exports;
-          if (!exports) continue;
-          const def = (exports.default ?? exports) as Record<string, unknown>;
-          if (typeof def?.getToken !== 'function') continue;
-          const result: unknown = (def.getToken as () => unknown)();
-          if (typeof result === 'string' && result.length > 0) {
-            token = result;
-            break;
+        // Guard: require.c can become null/undefined mid-iteration when the
+        // push mutates Discord's internal chunk array. Snapshot the values
+        // before iterating so a concurrent modification doesn't crash the loop.
+        let modules: { exports?: Record<string, unknown> }[];
+        try {
+          modules = Object.values(require.c ?? {});
+        } catch {
+          return;
+        }
+        for (const mod of modules) {
+          try {
+            const exports = mod?.exports;
+            if (!exports) continue;
+            const def = (exports.default ?? exports) as Record<string, unknown>;
+            if (typeof def?.getToken !== 'function') continue;
+            const result: unknown = (def.getToken as () => unknown)();
+            if (typeof result === 'string' && result.length > 0) {
+              token = result;
+              break;
+            }
+          } catch {
+            // Individual module access can throw; skip and continue.
+            continue;
           }
         }
       },


### PR DESCRIPTION
## Problem

The Discord plugin's `getTokenFromWebpack()` crashes when iterating Discord's webpack module cache. `require.c` can become `null`/`undefined` mid-iteration because the `chunks.push()` call mutates Discord's internal chunk array concurrently. This causes `Object.values(require.c)` to throw `"Cannot convert undefined or null to object"`, which is caught by the outer try/catch but leaves `token` as `null`.

The plugin then reports `isReady: false` permanently, with `"isReady() timed out"` warnings every 30 seconds in the extension logs.

### Evidence

Observed in production (April 2026). Discord currently has ~45 modules with a `getToken()` method (mostly i18n modules returning locale objects like `{locale, ast}`). Only 2 return the real auth token (string, ~70 chars). The crash occurs before the iterator reaches the auth modules.

The `extension_check_adapter` diagnostic shows: adapter injected, hash matches, `isReady: false`. The `extension_get_logs` output shows continuous `isReady() timed out` warnings. No errors, because the crash is silently caught.

## Fix

1. Snapshot `Object.values(require.c ?? {})` into a local array before iterating, so concurrent mutation of `require.c` doesn't affect the loop.
2. Wrap individual module access in try/catch so a single module throwing doesn't abort the search for the auth token.

## Test plan

- [x] Verified manually: after the fix, `getTokenFromWebpack()` successfully extracts the 70-char string token from Discord's webpack cache
- [ ] Extension reload with the patched adapter shows `isReady: true`
- [ ] Discord tools (`list_dms`, `send_message`, etc.) work after the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token extraction resilience with improved error handling to prevent failures in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->