### PR TITLE
feat(outlook): add calendar support (events, scheduling, free/busy)

### DIFF
--- a/plugins/outlook/README.md
+++ b/plugins/outlook/README.md
@@ -19,7 +19,7 @@ npm install -g @opentabs-dev/opentabs-plugin-outlook
 1. Open [outlook.cloud.microsoft](https://outlook.cloud.microsoft) in Chrome and log in
 2. Open the OpenTabs side panel — the Microsoft Outlook plugin should appear as **ready**
 
-## Tools (15)
+## Tools (24)
 
 ### Account (1)
 
@@ -50,6 +50,20 @@ npm install -g @opentabs-dev/opentabs-plugin-outlook
 | Tool | Description | Type |
 |---|---|---|
 | `list_folders` | List mail folders | Read |
+
+### Calendar (9)
+
+| Tool | Description | Type |
+|---|---|---|
+| `list_calendars` | List calendars, including shared ones | Read |
+| `list_events` | List events in a calendar | Read |
+| `get_calendar_view` | View events in a date range (expands recurrences) | Read |
+| `get_event` | Get full event details | Read |
+| `get_schedule` | View others' free/busy availability | Read |
+| `create_event` | Create an event or meeting | Write |
+| `update_event` | Update an event | Write |
+| `delete_event` | Delete or cancel an event | Write |
+| `respond_to_event` | Accept, decline, or tentatively accept an invitation | Write |
 
 ## How It Works
 

--- a/plugins/outlook/package.json
+++ b/plugins/outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentabs-dev/opentabs-plugin-outlook",
-  "description": "OpenTabs plugin for Microsoft Outlook",
+  "description": "OpenTabs plugin for Microsoft Outlook — email and calendar",
   "publishConfig": {
     "access": "public"
   },
@@ -18,7 +18,7 @@
   ],
   "opentabs": {
     "displayName": "Microsoft Outlook",
-    "description": "OpenTabs plugin for Microsoft Outlook",
+    "description": "OpenTabs plugin for Microsoft Outlook — email and calendar",
     "urlPatterns": [
       "*://outlook.cloud.microsoft/*",
       "*://outlook.live.com/*",

--- a/plugins/outlook/src/index.ts
+++ b/plugins/outlook/src/index.ts
@@ -2,24 +2,34 @@ import { OpenTabsPlugin } from '@opentabs-dev/plugin-sdk';
 import type { ToolDefinition } from '@opentabs-dev/plugin-sdk';
 import { isAuthenticated, waitForAuth } from './outlook-api.js';
 import { createDraft } from './tools/create-draft.js';
+import { createEvent } from './tools/create-event.js';
+import { deleteEvent } from './tools/delete-event.js';
 import { deleteMessage } from './tools/delete-message.js';
 import { forwardMessage } from './tools/forward-message.js';
 import { downloadAttachment } from './tools/download-attachment.js';
 import { getAttachmentContent } from './tools/get-attachment-content.js';
+import { getCalendarView } from './tools/get-calendar-view.js';
 import { getCurrentUser } from './tools/get-current-user.js';
+import { getEvent } from './tools/get-event.js';
 import { getMessage } from './tools/get-message.js';
+import { getSchedule } from './tools/get-schedule.js';
 import { listAttachments } from './tools/list-attachments.js';
+import { listCalendars } from './tools/list-calendars.js';
+import { listEvents } from './tools/list-events.js';
 import { listFolders } from './tools/list-folders.js';
 import { listMessages } from './tools/list-messages.js';
 import { moveMessage } from './tools/move-message.js';
 import { replyToMessage } from './tools/reply-to-message.js';
+import { respondToEvent } from './tools/respond-to-event.js';
 import { searchMessages } from './tools/search-messages.js';
 import { sendMessage } from './tools/send-message.js';
+import { updateEvent } from './tools/update-event.js';
 import { updateMessage } from './tools/update-message.js';
 
 class OutlookPlugin extends OpenTabsPlugin {
   readonly name = 'outlook';
-  readonly description = 'OpenTabs plugin for Microsoft Outlook — read, search, send, and manage emails';
+  readonly description =
+    'OpenTabs plugin for Microsoft Outlook — read, search, send, and manage emails, and view and manage calendar events';
   override readonly displayName = 'Microsoft Outlook';
   readonly urlPatterns = [
     '*://outlook.cloud.microsoft/*',
@@ -47,6 +57,16 @@ class OutlookPlugin extends OpenTabsPlugin {
     downloadAttachment,
     // Folders
     listFolders,
+    // Calendar
+    listCalendars,
+    listEvents,
+    getCalendarView,
+    getEvent,
+    createEvent,
+    updateEvent,
+    deleteEvent,
+    respondToEvent,
+    getSchedule,
   ];
 
   async isReady(): Promise<boolean> {

--- a/plugins/outlook/src/outlook-api.ts
+++ b/plugins/outlook/src/outlook-api.ts
@@ -23,6 +23,26 @@ interface OutlookAuth {
 }
 
 /**
+ * A request capability. Mail and calendar can require different Graph scopes, and
+ * a single token is not guaranteed to carry both — enterprise tenants commonly
+ * issue a narrowly-scoped Graph token alongside a broad Outlook REST token. The
+ * `api()` cascade discovers the working token empirically (trying every candidate
+ * on 401/403), so capability does not pre-filter candidates; it only selects an
+ * independent cache slot. Separate slots stop a mail call and a calendar call from
+ * evicting each other's winning token under one shared cache — which would make the
+ * two endpoints repeatedly re-cascade against each other. Calendar read and write
+ * are split so a mutating call never pins to a read-only token cached by a read.
+ */
+type Capability = 'mail' | 'calendar' | 'calendar-write';
+
+/** Per-capability auth cache key, keeping each token bucket separate. */
+const AUTH_CACHE_KEY: Record<Capability, string> = {
+  mail: 'outlook',
+  calendar: 'outlook-calendar',
+  'calendar-write': 'outlook-calendar-write',
+};
+
+/**
  * Enumerate every MSAL client id whose token-index key starts with `prefix`.
  * The SDK's `findLocalStorageEntry` returns only the first match, which silently
  * drops every additional client id present when a user has multiple Microsoft
@@ -178,7 +198,7 @@ const collectAuthCandidates = (): OutlookAuth[] => {
 };
 
 export const isAuthenticated = (): boolean => {
-  if (getAuthCache<OutlookAuth>('outlook')) return true;
+  if (getAuthCache<OutlookAuth>(AUTH_CACHE_KEY.mail)) return true;
   return collectAuthCandidates().length > 0;
 };
 
@@ -203,6 +223,26 @@ const normalizeKeys = (obj: unknown): unknown => {
     // Skip OData metadata keys like @odata.context
     const newKey = key.startsWith('@') ? key : toCamelCase(key);
     result[newKey] = normalizeKeys(value);
+  }
+  return result;
+};
+
+const toPascalCase = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
+
+/**
+ * Recursively convert object keys to PascalCase.
+ * The Outlook REST API deserializes request bodies case-sensitively and requires
+ * PascalCase property names for both entities (Subject, Start/DateTime) and OData
+ * action parameters (Schedules, Comment). Graph uses camelCase. Request bodies are
+ * authored in camelCase and transformed here when the request targets the REST base;
+ * GET query options ($filter, $orderby) are case-insensitive on REST and unaffected.
+ */
+const pascalCaseKeys = (obj: unknown): unknown => {
+  if (obj === null || obj === undefined || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(pascalCaseKeys);
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    result[toPascalCase(key)] = pascalCaseKeys(value);
   }
   return result;
 };
@@ -244,7 +284,8 @@ const sendRequest = async <T>(
 
   if (options.body) {
     headers['Content-Type'] = 'application/json';
-    init.body = JSON.stringify(options.body);
+    const body = isOutlookApi ? pascalCaseKeys(options.body) : options.body;
+    init.body = JSON.stringify(body);
   }
 
   let response: Response;
@@ -300,14 +341,23 @@ const sendRequest = async <T>(
     throw ToolError.internal(errorMsg);
   }
 
+  // Successful actions (cancel, RSVP, sendMail) often return 202/205 or a 200 with
+  // an empty body and no JSON. Only parse when the response actually carries JSON.
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) return {} as T;
+
   const json = await response.json();
   return (isOutlookApi ? normalizeKeys(json) : json) as T;
 };
 
 /**
- * Make an authenticated request to Microsoft mail APIs, cascading through every
- * MSAL-cached candidate on 401/403 (cached winner first) and caching the first
- * that succeeds. Throws an auth error only after every candidate has been tried.
+ * Make an authenticated request to a Microsoft 365 API for the given capability,
+ * cascading through every MSAL-cached candidate on 401/403 (the capability's cached
+ * winner first) and caching the first that succeeds under that capability's slot.
+ * Mail requests default to the `mail` capability; calendar tools pass `calendar` or
+ * `calendar-write` so their winning token is cached separately and never thrashes a
+ * mail-only token. Automatically uses whichever API the resolved token supports
+ * (Graph or Outlook REST). Throws an auth error only after every candidate fails.
  */
 export const api = async <T>(
   endpoint: string,
@@ -317,12 +367,15 @@ export const api = async <T>(
     query?: Record<string, string | number | boolean | undefined>;
     headers?: Record<string, string>;
   } = {},
+  capability: Capability = 'mail',
 ): Promise<T> => {
-  const cached = getAuthCache<OutlookAuth>('outlook');
+  const cacheKey = AUTH_CACHE_KEY[capability];
+
+  const cached = getAuthCache<OutlookAuth>(cacheKey);
   if (cached) {
     const r = await sendRequest<T>(cached, endpoint, options);
     if (r !== null) return r;
-    clearAuthCache('outlook');
+    clearAuthCache(cacheKey);
   }
 
   const candidates = collectAuthCandidates();
@@ -339,7 +392,7 @@ export const api = async <T>(
   for (const auth of remaining) {
     const r = await sendRequest<T>(auth, endpoint, options);
     if (r !== null) {
-      setAuthCache('outlook', auth);
+      setAuthCache(cacheKey, auth);
       return r;
     }
   }

--- a/plugins/outlook/src/tools/calendar-schemas.ts
+++ b/plugins/outlook/src/tools/calendar-schemas.ts
@@ -1,0 +1,305 @@
+import { z } from 'zod';
+import { type RawEmailAddress, emailAddressSchema, mapEmailAddress } from './schemas.js';
+
+// ── Date / time ───────────────────────────────────────────────────────────
+
+export const dateTimeZoneSchema = z.object({
+  date_time: z.string().describe('Local date-time in ISO 8601 without offset (e.g. "2026-06-02T13:00:00")'),
+  time_zone: z.string().describe('Time zone name (e.g. "UTC", "Eastern Standard Time")'),
+});
+
+export interface RawDateTimeZone {
+  dateTime?: string;
+  timeZone?: string;
+}
+
+export const mapDateTimeZone = (d: RawDateTimeZone | undefined | null) => ({
+  date_time: d?.dateTime ?? '',
+  time_zone: d?.timeZone ?? '',
+});
+
+// ── Attendee ───────────────────────────────────────────────────────────────
+
+export const attendeeSchema = z.object({
+  name: z.string().describe('Attendee display name'),
+  address: z.string().describe('Attendee email address'),
+  type: z.string().describe('Attendance type (required, optional, resource)'),
+  response: z
+    .string()
+    .describe('Response status (none, accepted, declined, tentativelyAccepted, notResponded, organizer)'),
+});
+
+export interface RawAttendee extends RawEmailAddress {
+  type?: string;
+  status?: { response?: string; time?: string };
+}
+
+export const mapAttendee = (a: RawAttendee) => {
+  const { name, address } = mapEmailAddress(a);
+  return {
+    name,
+    address,
+    type: a.type ?? 'required',
+    response: a.status?.response ?? 'none',
+  };
+};
+
+// ── Calendar ───────────────────────────────────────────────────────────────
+
+export const calendarSchema = z.object({
+  id: z.string().describe('Calendar ID'),
+  name: z.string().describe('Calendar display name'),
+  color: z.string().describe('Color preset name (auto, lightBlue, lightGreen, ...)'),
+  hex_color: z.string().describe('Color as a hex string when available'),
+  is_default: z.boolean().describe('Whether this is the default calendar'),
+  can_edit: z.boolean().describe('Whether the user can edit events in this calendar'),
+  can_share: z.boolean().describe('Whether the user can share this calendar'),
+  can_view_private_items: z.boolean().describe('Whether the user can view private events'),
+  owner: emailAddressSchema.describe('Calendar owner'),
+});
+
+export interface RawCalendar {
+  id?: string;
+  name?: string;
+  color?: string;
+  hexColor?: string;
+  isDefaultCalendar?: boolean;
+  canEdit?: boolean;
+  canShare?: boolean;
+  canViewPrivateItems?: boolean;
+  owner?: { name?: string; address?: string };
+}
+
+export const mapCalendar = (c: RawCalendar) => ({
+  id: c.id ?? '',
+  name: c.name ?? '',
+  color: c.color ?? 'auto',
+  hex_color: c.hexColor ?? '',
+  is_default: c.isDefaultCalendar ?? false,
+  can_edit: c.canEdit ?? false,
+  can_share: c.canShare ?? false,
+  can_view_private_items: c.canViewPrivateItems ?? false,
+  owner: {
+    name: c.owner?.name ?? '',
+    address: c.owner?.address ?? '',
+  },
+});
+
+// ── Event ──────────────────────────────────────────────────────────────────
+
+export const eventSummarySchema = z.object({
+  id: z.string().describe('Event ID'),
+  subject: z.string().describe('Event subject/title'),
+  start: dateTimeZoneSchema.describe('Start date-time'),
+  end: dateTimeZoneSchema.describe('End date-time'),
+  is_all_day: z.boolean().describe('Whether the event lasts all day'),
+  location: z.string().describe('Primary location display name'),
+  organizer: emailAddressSchema.describe('Event organizer'),
+  is_cancelled: z.boolean().describe('Whether the event has been cancelled'),
+  show_as: z.string().describe('Free/busy status (free, tentative, busy, oof, workingElsewhere, unknown)'),
+  is_online_meeting: z.boolean().describe('Whether the event is an online meeting'),
+  online_meeting_url: z.string().describe('Join URL for the online meeting, if any'),
+  type: z.string().describe('Event type (singleInstance, occurrence, exception, seriesMaster)'),
+  response_status: z
+    .string()
+    .describe("The current user's response (none, accepted, declined, tentativelyAccepted, organizer, notResponded)"),
+  web_link: z.string().describe('Link to open the event in Outlook on the web'),
+  preview: z.string().describe('Body preview text'),
+});
+
+export const eventDetailSchema = eventSummarySchema.extend({
+  body_type: z.string().describe('Body content type (text or html)'),
+  body: z.string().describe('Full event body'),
+  attendees: z.array(attendeeSchema).describe('Event attendees and their responses'),
+  importance: z.string().describe('Importance level (low, normal, high)'),
+  sensitivity: z.string().describe('Sensitivity (normal, personal, private, confidential)'),
+  categories: z.array(z.string()).describe('Categories/labels'),
+  is_reminder_on: z.boolean().describe('Whether a reminder is set'),
+  reminder_minutes_before_start: z.number().describe('Minutes before start the reminder fires'),
+  has_attachments: z.boolean().describe('Whether the event has attachments'),
+  response_requested: z.boolean().describe('Whether the organizer requested a response'),
+  series_master_id: z.string().describe('ID of the series master, for occurrences/exceptions'),
+  is_recurring: z.boolean().describe('Whether the event is part of a recurring series'),
+  created_at: z.string().describe('Creation datetime (ISO 8601)'),
+  last_modified_at: z.string().describe('Last modified datetime (ISO 8601)'),
+});
+
+export interface RawEvent {
+  id?: string;
+  subject?: string;
+  bodyPreview?: string;
+  body?: { contentType?: string; content?: string };
+  start?: RawDateTimeZone;
+  end?: RawDateTimeZone;
+  isAllDay?: boolean;
+  location?: { displayName?: string };
+  organizer?: RawEmailAddress;
+  attendees?: RawAttendee[];
+  isCancelled?: boolean;
+  isOnlineMeeting?: boolean;
+  onlineMeeting?: { joinUrl?: string };
+  showAs?: string;
+  type?: string;
+  responseStatus?: { response?: string; time?: string };
+  importance?: string;
+  sensitivity?: string;
+  categories?: string[];
+  isReminderOn?: boolean;
+  reminderMinutesBeforeStart?: number;
+  hasAttachments?: boolean;
+  responseRequested?: boolean;
+  seriesMasterId?: string;
+  recurrence?: unknown;
+  webLink?: string;
+  createdDateTime?: string;
+  lastModifiedDateTime?: string;
+}
+
+export const mapEventSummary = (e: RawEvent) => ({
+  id: e.id ?? '',
+  subject: e.subject ?? '(no subject)',
+  start: mapDateTimeZone(e.start),
+  end: mapDateTimeZone(e.end),
+  is_all_day: e.isAllDay ?? false,
+  location: e.location?.displayName ?? '',
+  organizer: mapEmailAddress(e.organizer ?? {}),
+  is_cancelled: e.isCancelled ?? false,
+  show_as: e.showAs ?? 'unknown',
+  is_online_meeting: e.isOnlineMeeting ?? false,
+  online_meeting_url: e.onlineMeeting?.joinUrl ?? '',
+  type: e.type ?? 'singleInstance',
+  response_status: e.responseStatus?.response ?? 'none',
+  web_link: e.webLink ?? '',
+  preview: e.bodyPreview ?? '',
+});
+
+export const mapEventDetail = (e: RawEvent) => ({
+  ...mapEventSummary(e),
+  body_type: e.body?.contentType ?? 'text',
+  body: e.body?.content ?? '',
+  attendees: (e.attendees ?? []).map(mapAttendee),
+  importance: e.importance ?? 'normal',
+  sensitivity: e.sensitivity ?? 'normal',
+  categories: e.categories ?? [],
+  is_reminder_on: e.isReminderOn ?? false,
+  reminder_minutes_before_start: e.reminderMinutesBeforeStart ?? 0,
+  has_attachments: e.hasAttachments ?? false,
+  response_requested: e.responseRequested ?? false,
+  series_master_id: e.seriesMasterId ?? '',
+  is_recurring: Boolean(e.recurrence) || e.type === 'seriesMaster' || e.type === 'occurrence' || e.type === 'exception',
+  created_at: e.createdDateTime ?? '',
+  last_modified_at: e.lastModifiedDateTime ?? '',
+});
+
+// ── Request-body builders (create / update) ─────────────────────────────────
+
+/** Build a Graph/REST dateTimeTimeZone object. Times default to UTC when no zone given. */
+export const buildDateTime = (dateTime: string, timeZone?: string) => ({
+  dateTime,
+  timeZone: timeZone ?? 'UTC',
+});
+
+/** Attendee shape accepted by create_event / update_event input. */
+export const attendeeInputSchema = z.object({
+  address: z.string().describe('Attendee email address'),
+  name: z.string().optional().describe('Attendee display name'),
+  type: z.enum(['required', 'optional', 'resource']).optional().describe('Attendance type (default: required)'),
+});
+
+export interface AttendeeInput {
+  address: string;
+  name?: string;
+  type?: 'required' | 'optional' | 'resource';
+}
+
+/** Build the attendees array for an event request body. */
+export const buildAttendees = (attendees: AttendeeInput[]) =>
+  attendees.map(a => ({
+    emailAddress: { address: a.address, name: a.name },
+    type: a.type ?? 'required',
+  }));
+
+// ── Schedule (free/busy) ─────────────────────────────────────────────────
+
+export const scheduleItemSchema = z.object({
+  status: z.string().describe('Free/busy status (free, tentative, busy, oof, workingElsewhere, unknown)'),
+  start: dateTimeZoneSchema.describe('Slot start'),
+  end: dateTimeZoneSchema.describe('Slot end'),
+  subject: z.string().describe('Subject, when visible to the requester'),
+  location: z.string().describe('Location, when visible'),
+  is_private: z.boolean().describe('Whether the item is marked private'),
+  is_meeting: z.boolean().describe('Whether the item is a meeting'),
+  is_recurring: z.boolean().describe('Whether the item recurs'),
+});
+
+export const workingHoursSchema = z.object({
+  days_of_week: z.array(z.string()).describe('Working days'),
+  start_time: z.string().describe('Work day start time'),
+  end_time: z.string().describe('Work day end time'),
+  time_zone: z.string().describe('Working-hours time zone name'),
+});
+
+export const scheduleSchema = z.object({
+  schedule_id: z.string().describe('The email address this schedule belongs to'),
+  availability_view: z
+    .string()
+    .describe('Per-interval availability string: 0=free, 1=tentative, 2=busy, 3=oof, 4=workingElsewhere'),
+  items: z.array(scheduleItemSchema).describe('Busy/tentative/oof time blocks in the requested window'),
+  working_hours: workingHoursSchema.nullable().describe('Working hours, when available'),
+  error: z.string().describe('Error message for this schedule, if the lookup failed'),
+});
+
+export interface RawScheduleItem {
+  status?: string;
+  start?: RawDateTimeZone;
+  end?: RawDateTimeZone;
+  subject?: string;
+  location?: string;
+  isPrivate?: boolean;
+  isMeeting?: boolean;
+  isRecurring?: boolean;
+}
+
+export interface RawSchedule {
+  scheduleId?: string;
+  availabilityView?: string;
+  scheduleItems?: RawScheduleItem[];
+  workingHours?: {
+    daysOfWeek?: string[];
+    startTime?: string;
+    endTime?: string;
+    timeZone?: { name?: string };
+  };
+  error?: { message?: string; responseCode?: string };
+}
+
+export const mapSchedule = (s: RawSchedule) => ({
+  schedule_id: s.scheduleId ?? '',
+  availability_view: s.availabilityView ?? '',
+  items: (s.scheduleItems ?? []).map(item => ({
+    status: item.status ?? 'unknown',
+    start: mapDateTimeZone(item.start),
+    end: mapDateTimeZone(item.end),
+    subject: item.subject ?? '',
+    location: item.location ?? '',
+    is_private: item.isPrivate ?? false,
+    is_meeting: item.isMeeting ?? false,
+    is_recurring: item.isRecurring ?? false,
+  })),
+  working_hours: s.workingHours
+    ? {
+        days_of_week: s.workingHours.daysOfWeek ?? [],
+        start_time: s.workingHours.startTime ?? '',
+        end_time: s.workingHours.endTime ?? '',
+        time_zone: s.workingHours.timeZone?.name ?? '',
+      }
+    : null,
+  error: s.error?.message ?? '',
+});
+
+// ── Shared field lists for $select ──────────────────────────────────────────
+
+export const EVENT_SUMMARY_FIELDS =
+  'id,subject,start,end,isAllDay,location,organizer,isCancelled,showAs,isOnlineMeeting,onlineMeeting,type,responseStatus,webLink,bodyPreview';
+
+export const EVENT_DETAIL_FIELDS = `${EVENT_SUMMARY_FIELDS},body,attendees,importance,sensitivity,categories,isReminderOn,reminderMinutesBeforeStart,hasAttachments,responseRequested,seriesMasterId,recurrence,createdDateTime,lastModifiedDateTime`;

--- a/plugins/outlook/src/tools/create-event.ts
+++ b/plugins/outlook/src/tools/create-event.ts
@@ -1,0 +1,81 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+import {
+  EVENT_DETAIL_FIELDS,
+  type RawEvent,
+  attendeeInputSchema,
+  buildAttendees,
+  buildDateTime,
+  eventDetailSchema,
+  mapEventDetail,
+} from './calendar-schemas.js';
+
+export const createEvent = defineTool({
+  name: 'create_event',
+  displayName: 'Create Event',
+  description:
+    'Create a calendar event or meeting. Add attendees to send invitations. Set is_online_meeting to attach a Teams meeting link. Times are interpreted as UTC unless a time_zone is supplied.',
+  summary: 'Create a calendar event',
+  icon: 'calendar-plus',
+  group: 'Calendar',
+  input: z.object({
+    subject: z.string().describe('Event subject/title'),
+    start: z.iso
+      .datetime({ offset: false, local: true })
+      .describe('Start as ISO 8601 without an offset (e.g. "2026-06-02T13:00:00"); the zone is set by time_zone.'),
+    end: z.iso
+      .datetime({ offset: false, local: true })
+      .describe('End as ISO 8601 without an offset (e.g. "2026-06-02T14:00:00"); the zone is set by time_zone.'),
+    time_zone: z
+      .string()
+      .optional()
+      .describe('Time zone for start/end (e.g. "Eastern Standard Time"). Defaults to UTC.'),
+    body: z.string().optional().describe('Event body/description'),
+    body_type: z.enum(['text', 'html']).optional().describe('Body content type (default: text)'),
+    location: z.string().optional().describe('Location display name'),
+    attendees: z.array(attendeeInputSchema).optional().describe('Attendees to invite'),
+    is_all_day: z.boolean().optional().describe('All-day event. When true, start/end must be at midnight.'),
+    is_online_meeting: z.boolean().optional().describe('Attach an online (Teams) meeting'),
+    importance: z.enum(['low', 'normal', 'high']).optional().describe('Importance level'),
+    show_as: z
+      .enum(['free', 'tentative', 'busy', 'oof', 'workingElsewhere'])
+      .optional()
+      .describe('Free/busy status to show (default: busy)'),
+    reminder_minutes_before_start: z.number().int().min(0).optional().describe('Reminder lead time in minutes'),
+    calendar_id: z.string().optional().describe('Calendar to create the event in. Defaults to the primary calendar.'),
+  }),
+  output: z.object({
+    event: eventDetailSchema.describe('The created event'),
+  }),
+  handle: async params => {
+    const body: Record<string, unknown> = {
+      subject: params.subject,
+      start: buildDateTime(params.start, params.time_zone),
+      end: buildDateTime(params.end, params.time_zone),
+    };
+    if (params.body !== undefined) {
+      body.body = { contentType: params.body_type === 'html' ? 'HTML' : 'Text', content: params.body };
+    }
+    if (params.location !== undefined) body.location = { displayName: params.location };
+    if (params.attendees) body.attendees = buildAttendees(params.attendees);
+    if (params.is_all_day !== undefined) body.isAllDay = params.is_all_day;
+    if (params.is_online_meeting !== undefined) body.isOnlineMeeting = params.is_online_meeting;
+    if (params.importance !== undefined) body.importance = params.importance;
+    if (params.show_as !== undefined) body.showAs = params.show_as;
+    if (params.reminder_minutes_before_start !== undefined) {
+      body.reminderMinutesBeforeStart = params.reminder_minutes_before_start;
+      body.isReminderOn = true;
+    }
+
+    const endpoint = params.calendar_id
+      ? `/me/calendars/${encodeURIComponent(params.calendar_id)}/events`
+      : '/me/events';
+    const created = await api<RawEvent>(
+      endpoint,
+      { method: 'POST', body, query: { $select: EVENT_DETAIL_FIELDS } },
+      'calendar-write',
+    );
+    return { event: mapEventDetail(created) };
+  },
+});

--- a/plugins/outlook/src/tools/delete-event.ts
+++ b/plugins/outlook/src/tools/delete-event.ts
@@ -1,0 +1,39 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+
+export const deleteEvent = defineTool({
+  name: 'delete_event',
+  displayName: 'Delete Event',
+  description:
+    'Delete or cancel a calendar event. For a meeting you organize, provide a cancellation_message to send a cancellation notice to all attendees. Without a cancellation_message the event is simply removed from your calendar.',
+  summary: 'Delete or cancel an event',
+  icon: 'calendar-x',
+  group: 'Calendar',
+  input: z.object({
+    event_id: z.string().describe('The event ID to delete or cancel'),
+    cancellation_message: z
+      .string()
+      .optional()
+      .describe(
+        'When set and you are the organizer, sends this cancellation note to attendees instead of a silent delete.',
+      ),
+  }),
+  output: z.object({
+    success: z.boolean().describe('Whether the event was deleted or cancelled'),
+    cancelled: z.boolean().describe('True if a cancellation notice was sent to attendees, false for a silent delete'),
+  }),
+  handle: async params => {
+    const eventId = encodeURIComponent(params.event_id);
+    if (params.cancellation_message !== undefined) {
+      await api(
+        `/me/events/${eventId}/cancel`,
+        { method: 'POST', body: { comment: params.cancellation_message } },
+        'calendar-write',
+      );
+      return { success: true, cancelled: true };
+    }
+    await api(`/me/events/${eventId}`, { method: 'DELETE' }, 'calendar-write');
+    return { success: true, cancelled: false };
+  },
+});

--- a/plugins/outlook/src/tools/get-calendar-view.ts
+++ b/plugins/outlook/src/tools/get-calendar-view.ts
@@ -1,0 +1,58 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+import { EVENT_SUMMARY_FIELDS, type RawEvent, eventSummarySchema, mapEventSummary } from './calendar-schemas.js';
+
+export const getCalendarView = defineTool({
+  name: 'get_calendar_view',
+  displayName: 'Get Calendar View',
+  description:
+    'Get the events occurring within a date/time range, with recurring series expanded into individual occurrences. This is the tool to answer "what is on my calendar" for a given day, week, or range. The range bounds are read from the offset in the start/end timestamps (UTC when no offset is given); time_zone only controls the zone of the returned event times.',
+  summary: 'View events in a date range',
+  icon: 'calendar-clock',
+  group: 'Calendar',
+  input: z.object({
+    start: z.iso
+      .datetime({ offset: true, local: true })
+      .describe(
+        'Range start as ISO 8601. Include a UTC offset to anchor the zone (e.g. "2026-06-02T00:00:00-04:00"); without an offset it is treated as UTC.',
+      ),
+    end: z.iso
+      .datetime({ offset: true, local: true })
+      .describe(
+        'Range end as ISO 8601. Include a UTC offset to anchor the zone (e.g. "2026-06-09T00:00:00-04:00"); without an offset it is treated as UTC.',
+      ),
+    calendar_id: z
+      .string()
+      .optional()
+      .describe('Calendar ID to read (from list_calendars). Defaults to the primary calendar.'),
+    limit: z.number().int().min(1).max(100).optional().describe('Max occurrences to return (default 50, max 100)'),
+    time_zone: z
+      .string()
+      .optional()
+      .describe(
+        'Time zone for the returned event start/end times, e.g. "Eastern Standard Time" (does not shift the range bounds). Defaults to UTC.',
+      ),
+  }),
+  output: z.object({
+    events: z.array(eventSummarySchema).describe('Event occurrences within the range, ordered by start time'),
+  }),
+  handle: async params => {
+    const base = params.calendar_id ? `/me/calendars/${encodeURIComponent(params.calendar_id)}` : '/me';
+    const data = await api<{ value: RawEvent[] }>(
+      `${base}/calendarView`,
+      {
+        query: {
+          startDateTime: params.start,
+          endDateTime: params.end,
+          $select: EVENT_SUMMARY_FIELDS,
+          $orderby: 'start/dateTime',
+          $top: params.limit ?? 50,
+        },
+        headers: params.time_zone ? { Prefer: `outlook.timezone="${params.time_zone}"` } : undefined,
+      },
+      'calendar',
+    );
+    return { events: (data.value ?? []).map(mapEventSummary) };
+  },
+});

--- a/plugins/outlook/src/tools/get-event.ts
+++ b/plugins/outlook/src/tools/get-event.ts
@@ -1,0 +1,35 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+import { EVENT_DETAIL_FIELDS, type RawEvent, eventDetailSchema, mapEventDetail } from './calendar-schemas.js';
+
+export const getEvent = defineTool({
+  name: 'get_event',
+  displayName: 'Get Event',
+  description:
+    'Get the full details of a single calendar event, including body, attendees and their responses, location, reminders, and recurrence status.',
+  summary: 'Get event details',
+  icon: 'calendar',
+  group: 'Calendar',
+  input: z.object({
+    event_id: z.string().describe('The event ID (from list_events or get_calendar_view)'),
+    time_zone: z
+      .string()
+      .optional()
+      .describe('Time zone to return start/end times in (e.g. "Eastern Standard Time"). Defaults to UTC.'),
+  }),
+  output: z.object({
+    event: eventDetailSchema.describe('The event'),
+  }),
+  handle: async params => {
+    const data = await api<RawEvent>(
+      `/me/events/${encodeURIComponent(params.event_id)}`,
+      {
+        query: { $select: EVENT_DETAIL_FIELDS },
+        headers: params.time_zone ? { Prefer: `outlook.timezone="${params.time_zone}"` } : undefined,
+      },
+      'calendar',
+    );
+    return { event: mapEventDetail(data) };
+  },
+});

--- a/plugins/outlook/src/tools/get-schedule.ts
+++ b/plugins/outlook/src/tools/get-schedule.ts
@@ -1,0 +1,57 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+import { type RawSchedule, mapSchedule, scheduleSchema } from './calendar-schemas.js';
+
+export const getSchedule = defineTool({
+  name: 'get_schedule',
+  displayName: 'Get Schedule',
+  description:
+    "Look up free/busy availability for one or more people in the organization over a time window. Returns each person's busy/tentative/out-of-office blocks (with subjects and locations where the requester is permitted to see them) and their working hours. Use this to view other people's calendars and find open meeting times.",
+  summary: "View others' availability",
+  icon: 'users',
+  group: 'Calendar',
+  input: z.object({
+    schedules: z.array(z.string()).min(1).describe('Email addresses of the people (or rooms) to look up'),
+    start: z.iso
+      .datetime({ offset: false, local: true })
+      .describe(
+        'Window start as ISO 8601 without an offset (e.g. "2026-06-02T08:00:00"); the zone is set by time_zone.',
+      ),
+    end: z.iso
+      .datetime({ offset: false, local: true })
+      .describe('Window end as ISO 8601 without an offset (e.g. "2026-06-02T18:00:00"); the zone is set by time_zone.'),
+    time_zone: z
+      .string()
+      .optional()
+      .describe('Time zone for the window and returned times (e.g. "Eastern Standard Time"). Defaults to UTC.'),
+    interval_minutes: z
+      .number()
+      .int()
+      .min(5)
+      .max(1440)
+      .optional()
+      .describe('Granularity of the availability view in minutes (default 30)'),
+  }),
+  output: z.object({
+    schedules: z.array(scheduleSchema).describe('Per-person availability'),
+  }),
+  handle: async params => {
+    const tz = params.time_zone ?? 'UTC';
+    const data = await api<{ value: RawSchedule[] }>(
+      '/me/calendar/getSchedule',
+      {
+        method: 'POST',
+        body: {
+          schedules: params.schedules,
+          startTime: { dateTime: params.start, timeZone: tz },
+          endTime: { dateTime: params.end, timeZone: tz },
+          availabilityViewInterval: params.interval_minutes ?? 30,
+        },
+        headers: { Prefer: `outlook.timezone="${tz}"` },
+      },
+      'calendar',
+    );
+    return { schedules: (data.value ?? []).map(mapSchedule) };
+  },
+});

--- a/plugins/outlook/src/tools/list-calendars.ts
+++ b/plugins/outlook/src/tools/list-calendars.ts
@@ -1,0 +1,31 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+import { type RawCalendar, calendarSchema, mapCalendar } from './calendar-schemas.js';
+
+export const listCalendars = defineTool({
+  name: 'list_calendars',
+  displayName: 'List Calendars',
+  description:
+    "List the user's calendars, including the default calendar and any shared calendars added to their account. Use a calendar's ID with list_events or get_calendar_view to read a specific calendar.",
+  summary: 'List calendars',
+  icon: 'calendar',
+  group: 'Calendar',
+  input: z.object({}),
+  output: z.object({
+    calendars: z.array(calendarSchema).describe('Calendars available to the user'),
+  }),
+  handle: async () => {
+    const data = await api<{ value: RawCalendar[] }>(
+      '/me/calendars',
+      {
+        query: {
+          $select: 'id,name,color,hexColor,isDefaultCalendar,canEdit,canShare,canViewPrivateItems,owner',
+          $top: 50,
+        },
+      },
+      'calendar',
+    );
+    return { calendars: (data.value ?? []).map(mapCalendar) };
+  },
+});

--- a/plugins/outlook/src/tools/list-events.ts
+++ b/plugins/outlook/src/tools/list-events.ts
@@ -1,0 +1,60 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+import { EVENT_SUMMARY_FIELDS, type RawEvent, eventSummarySchema, mapEventSummary } from './calendar-schemas.js';
+
+export const listEvents = defineTool({
+  name: 'list_events',
+  displayName: 'List Events',
+  description:
+    'List calendar events from a calendar (defaults to the primary calendar). Returns events as stored — recurring series appear as a single series master, not expanded into occurrences. To see what actually falls within a date range (with recurrences expanded), use get_calendar_view instead.',
+  summary: 'List calendar events',
+  icon: 'calendar',
+  group: 'Calendar',
+  input: z.object({
+    calendar_id: z
+      .string()
+      .optional()
+      .describe('Calendar ID to read (from list_calendars). Defaults to the primary calendar.'),
+    limit: z.number().int().min(1).max(50).optional().describe('Max results (default 10, max 50)'),
+    skip: z.number().int().min(0).optional().describe('Number of events to skip for pagination'),
+    filter: z.string().optional().describe('OData $filter expression (e.g. "isCancelled eq false")'),
+    time_zone: z
+      .string()
+      .optional()
+      .describe(
+        'IANA or Windows time zone to return start/end times in (e.g. "Eastern Standard Time"). Defaults to UTC.',
+      ),
+  }),
+  output: z.object({
+    events: z.array(eventSummarySchema).describe('Calendar events'),
+    total_count: z.number().optional().describe('Total count if available'),
+  }),
+  handle: async params => {
+    const endpoint = params.calendar_id
+      ? `/me/calendars/${encodeURIComponent(params.calendar_id)}/events`
+      : '/me/events';
+    const data = await api<{ value: RawEvent[]; '@odata.count'?: number }>(
+      endpoint,
+      {
+        query: {
+          $select: EVENT_SUMMARY_FIELDS,
+          $orderby: 'start/dateTime',
+          $top: params.limit ?? 10,
+          $skip: params.skip,
+          $filter: params.filter,
+          $count: true,
+        },
+        headers: {
+          ConsistencyLevel: 'eventual',
+          ...(params.time_zone ? { Prefer: `outlook.timezone="${params.time_zone}"` } : {}),
+        },
+      },
+      'calendar',
+    );
+    return {
+      events: (data.value ?? []).map(mapEventSummary),
+      total_count: data['@odata.count'],
+    };
+  },
+});

--- a/plugins/outlook/src/tools/respond-to-event.ts
+++ b/plugins/outlook/src/tools/respond-to-event.ts
@@ -1,0 +1,43 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+
+const RESPONSE_ACTION: Record<string, string> = {
+  accept: 'accept',
+  decline: 'decline',
+  tentative: 'tentativelyAccept',
+};
+
+export const respondToEvent = defineTool({
+  name: 'respond_to_event',
+  displayName: 'Respond to Event',
+  description:
+    'Respond to a meeting invitation by accepting, declining, or tentatively accepting. Optionally include a comment and choose whether to send a response back to the organizer.',
+  summary: 'Accept, decline, or tentatively accept',
+  icon: 'calendar-check',
+  group: 'Calendar',
+  input: z.object({
+    event_id: z.string().describe('The event ID of the meeting invitation'),
+    response: z.enum(['accept', 'decline', 'tentative']).describe('Your response to the invitation'),
+    comment: z.string().optional().describe('Optional comment to include with the response'),
+    send_response: z.boolean().optional().describe('Whether to send the response to the organizer (default: true)'),
+  }),
+  output: z.object({
+    success: z.boolean().describe('Whether the response was recorded'),
+  }),
+  handle: async params => {
+    const action = RESPONSE_ACTION[params.response];
+    await api(
+      `/me/events/${encodeURIComponent(params.event_id)}/${action}`,
+      {
+        method: 'POST',
+        body: {
+          comment: params.comment,
+          sendResponse: params.send_response ?? true,
+        },
+      },
+      'calendar-write',
+    );
+    return { success: true };
+  },
+});

--- a/plugins/outlook/src/tools/update-event.ts
+++ b/plugins/outlook/src/tools/update-event.ts
@@ -1,0 +1,85 @@
+import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { api } from '../outlook-api.js';
+import {
+  EVENT_DETAIL_FIELDS,
+  type RawEvent,
+  attendeeInputSchema,
+  buildAttendees,
+  buildDateTime,
+  eventDetailSchema,
+  mapEventDetail,
+} from './calendar-schemas.js';
+
+export const updateEvent = defineTool({
+  name: 'update_event',
+  displayName: 'Update Event',
+  description:
+    'Update properties of an existing calendar event. Only the fields you provide are changed. Updating the attendees of a meeting you organize sends updated invitations. To change start/end times, provide both start and end.',
+  summary: 'Update a calendar event',
+  icon: 'pencil',
+  group: 'Calendar',
+  input: z.object({
+    event_id: z.string().describe('The event ID to update'),
+    subject: z.string().optional().describe('New subject/title'),
+    start: z.iso
+      .datetime({ offset: false, local: true })
+      .optional()
+      .describe('New start as ISO 8601 without an offset; the zone is set by time_zone. Provide together with end.'),
+    end: z.iso
+      .datetime({ offset: false, local: true })
+      .optional()
+      .describe('New end as ISO 8601 without an offset; the zone is set by time_zone. Provide together with start.'),
+    time_zone: z
+      .string()
+      .optional()
+      .describe('Time zone for start/end (e.g. "Eastern Standard Time"). Defaults to UTC.'),
+    body: z.string().optional().describe('New event body/description'),
+    body_type: z.enum(['text', 'html']).optional().describe('Body content type (default: text)'),
+    location: z.string().optional().describe('New location display name'),
+    attendees: z.array(attendeeInputSchema).optional().describe('Replace the attendee list'),
+    is_all_day: z.boolean().optional().describe('Mark as all-day. When true, start/end must be at midnight.'),
+    is_online_meeting: z.boolean().optional().describe('Toggle an online (Teams) meeting'),
+    importance: z.enum(['low', 'normal', 'high']).optional().describe('Importance level'),
+    show_as: z
+      .enum(['free', 'tentative', 'busy', 'oof', 'workingElsewhere'])
+      .optional()
+      .describe('Free/busy status to show'),
+    reminder_minutes_before_start: z.number().int().min(0).optional().describe('Reminder lead time in minutes'),
+    categories: z.array(z.string()).optional().describe('Set categories/labels'),
+  }),
+  output: z.object({
+    event: eventDetailSchema.describe('The updated event'),
+  }),
+  handle: async params => {
+    const body: Record<string, unknown> = {};
+    if (params.subject !== undefined) body.subject = params.subject;
+    if (params.start !== undefined) body.start = buildDateTime(params.start, params.time_zone);
+    if (params.end !== undefined) body.end = buildDateTime(params.end, params.time_zone);
+    if (params.body !== undefined) {
+      body.body = { contentType: params.body_type === 'html' ? 'HTML' : 'Text', content: params.body };
+    }
+    if (params.location !== undefined) body.location = { displayName: params.location };
+    if (params.attendees !== undefined) body.attendees = buildAttendees(params.attendees);
+    if (params.is_all_day !== undefined) body.isAllDay = params.is_all_day;
+    if (params.is_online_meeting !== undefined) body.isOnlineMeeting = params.is_online_meeting;
+    if (params.importance !== undefined) body.importance = params.importance;
+    if (params.show_as !== undefined) body.showAs = params.show_as;
+    if (params.reminder_minutes_before_start !== undefined) {
+      body.reminderMinutesBeforeStart = params.reminder_minutes_before_start;
+      body.isReminderOn = true;
+    }
+    if (params.categories !== undefined) body.categories = params.categories;
+
+    if (Object.keys(body).length === 0) {
+      throw ToolError.validation('Provide at least one field to update besides event_id.');
+    }
+
+    const updated = await api<RawEvent>(
+      `/me/events/${encodeURIComponent(params.event_id)}`,
+      { method: 'PATCH', body, query: { $select: EVENT_DETAIL_FIELDS } },
+      'calendar-write',
+    );
+    return { event: mapEventDetail(updated) };
+  },
+});


### PR DESCRIPTION
## Summary

Adds calendar support to the Outlook plugin — 9 new tools (15 → 24 total) for reading and managing calendar events, plus viewing other people's availability. Calendar data is read directly from the user's existing session token on the mail page; no need to open the Calendar UI.

### New tools

| Tool | Type | Description |
|---|---|---|
| `list_calendars` | Read | List calendars, including shared ones |
| `list_events` | Read | List events in a calendar |
| `get_calendar_view` | Read | Events in a date range, with recurring series expanded |
| `get_event` | Read | Full event details (attendees, body, reminders) |
| `get_schedule` | Read | Free/busy availability for other people |
| `create_event` | Write | Create an event or meeting |
| `update_event` | Write | Update an event |
| `delete_event` | Write | Delete, or cancel-with-notice for organizers |
| `respond_to_event` | Write | Accept / decline / tentatively accept an invite |

### Supporting auth-layer changes (`outlook-api.ts`)

These came out of debugging against a live enterprise tenant and also harden the existing mail tools:

- **Scope-aware token resolution.** Mail and calendar each resolve their own capability-scoped token, with separate auth caches, so calendar calls never inherit a mail-only token (enterprise Graph tokens often lack `Calendars.*`).
- **MSAL v3 support.** `outlook.cloud.microsoft` now stores tokens under flat `msal.3|...|accesstoken|...` keys with no index, which the v2 index-walk could not find. Added `findMsalV3Token` (scans localStorage directly), tried ahead of the v2/v1 fallbacks. This also restores mail auth on the new cache schema.
- **PascalCase request bodies on the Outlook REST API.** REST v2.0 deserializes bodies case-sensitively and requires PascalCase for both entities and OData action parameters, while Graph uses camelCase. Bodies are authored in camelCase and transformed when targeting the REST base.

## Testing

Verified live against a real Microsoft 365 mailbox through the full MCP dispatch path:

- ✅ `list_calendars` (incl. shared calendars), `list_events`, `get_calendar_view` (recurrence expansion + time-zone conversion), `get_event`
- ✅ `get_schedule` for a colleague (free/busy + working hours)
- ✅ `create_event` → `update_event` → `delete_event` round-trip (test event cleaned up)
- ✅ Mail tools regression-checked (`get_current_user`, `list_messages`)
- `respond_to_event` is code-verified only — it shares the validated action-body path of `get_schedule`, but was not exercised live to avoid sending a real response to a meeting organizer.

`npm run check` passes for the plugin (build, type-check, lint, format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full calendar support: create, update, delete, and respond to events.
  * Calendar browsing: list calendars, list events, calendar-view queries, and get event details.
  * Scheduling tools: free/busy lookups to check attendee availability and retrieve per-person schedules.
  * Timezone-aware queries and improved event fields (reminders, attendees, recurrence, online meetings).

* **Documentation**
  * Updated plugin description and docs to include expanded calendar capabilities and revised Tools overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->