### PR TITLE
feat(extension): inject pre-scripts into all matching same-origin frames

### DIFF
--- a/platform/browser-extension/src/pre-script-registration.ts
+++ b/platform/browser-extension/src/pre-script-registration.ts
@@ -59,7 +59,23 @@ const upsertPreScript = async (meta: PluginMeta): Promise<void> => {
         runAt: 'document_start',
         world: 'MAIN',
         persistAcrossSessions: true,
-        allFrames: false,
+        // Inject into every matching same-origin frame, not just the top
+        // window. Auth frameworks such as SharePoint's WAC/Owl mint MSAL
+        // silent-renewal tokens inside same-origin sub-frames; a pre-script
+        // that runs only in the top window never sees those requests, because
+        // each frame has its own `window.fetch`/`XMLHttpRequest` to intercept.
+        //
+        // Per-frame injection is safe because each frame is a separate realm:
+        // the script runs independently in each, top-frame behavior is
+        // unchanged, and every frame's `globalThis.__openTabs` store is its
+        // own — there is no shared in-page state to double-write. A pre-script
+        // that wants a captured value to reach the top-frame adapter bridges
+        // it through a same-origin channel (e.g. `localStorage`), which all
+        // frames share; the per-realm `__openTabs` namespace does not cross
+        // frames. Cross-origin frames (e.g. a WOPI document canvas) are never
+        // injected — Chrome only matches frames whose URL satisfies
+        // `meta.urlPatterns`.
+        allFrames: true,
       },
     ]);
   } catch (err) {


### PR DESCRIPTION
## Summary

Splits out the pre-script injection-semantics change requested in the review of #100. Registers plugin pre-scripts with `allFrames: true` so they run in **every same-origin frame** whose URL matches the plugin's patterns, not only the top window.

This is an isolated platform decision that affects every plugin's pre-script, so it's reviewed here on its own merits rather than bundled into a feature PR.

## Why

Auth frameworks such as SharePoint's WAC/Owl mint MSAL silent-renewal tokens inside same-origin **sub-frames**. A pre-script that runs only in the top window never observes those token requests — each frame has its own `window.fetch`/`XMLHttpRequest` to intercept. Per-frame injection is required for any pre-script that captures auth from sub-frame traffic (e.g. the SharePoint/OneDrive Office support in #100).

## Why it's safe

Each frame is a **separate realm**:

- The script runs independently in each frame; top-frame behavior is unchanged.
- Every frame's `globalThis.__openTabs` store is its own — there is no shared in-page state to double-write, so injecting into N frames does not stack or collide.
- The per-realm `__openTabs` namespace deliberately **does not cross frames**. A pre-script that needs a captured value to reach the top-frame adapter bridges it through a same-origin channel such as `localStorage` (which all same-origin frames share). That is exactly how the Office pre-scripts hand a sub-frame-captured Graph token to their top-frame adapter.
- Cross-origin frames (e.g. a WOPI document canvas) are **never** injected — Chrome only matches frames whose URL satisfies `meta.urlPatterns`.

## Note on the prior comment

The earlier inline comment justified this with a claim that "all shipped pre-scripts use a `Symbol.for(...)` marker so a second injection is a no-op." That was inaccurate — only some pre-scripts carry such a marker, and it is not the reason this is safe. The reason is realm isolation, as described above and now stated correctly in the code comment.