### PR TITLE
Draft: add Firefox WebExtension background transport

### DIFF
--- a/platform/browser-extension/build-extension.ts
+++ b/platform/browser-extension/build-extension.ts
@@ -105,11 +105,20 @@ for (const { entrypoint, outfile, label } of entries) {
       bundle: true,
       platform: 'browser',
       format: 'esm',
-      minify: false,
+      // Keep Chrome output readable/unchanged; minify only Firefox so the build-time
+      // target gate removes Chrome-only dead branches before AMO/Firefox sees them.
+      minify: target === 'firefox',
+      // Firefox relies on build-time target gates to exclude Chrome-only APIs
+      // such as chrome.offscreen from the background bundle. minifySyntax folds
+      // those constant branches without changing the default Chrome output.
+      minifySyntax: target === 'firefox',
       // Write directly to the exact output path, overwriting the tsc-produced file.
       allowOverwrite: true,
       banner,
-      define: { __OPENTABS_TARGET__: JSON.stringify(target) },
+      define: {
+        __OPENTABS_TARGET__: JSON.stringify(target),
+        __OPENTABS_IS_FIREFOX__: JSON.stringify(target === 'firefox'),
+      },
       plugins: [stubNodeBuiltins],
     });
 

--- a/platform/browser-extension/build-extension.ts
+++ b/platform/browser-extension/build-extension.ts
@@ -48,6 +48,11 @@ execSync('npx tsc --build', { cwd: base, stdio: 'inherit' });
 
 const isDev = process.env.OPENTABS_DEV === '1';
 
+// Build target: 'chrome' (default) or 'firefox'. Inlined into the bundle via an
+// esbuild `define` so the transport layer can dead-code-eliminate the unused
+// platform path. The default leaves Chrome output byte-for-byte unchanged.
+const target = process.env.OPENTABS_TARGET === 'firefox' ? 'firefox' : 'chrome';
+
 // In dev mode, prepend the dev reload WebSocket client to the background bundle.
 // The client connects to the relay server and triggers chrome.runtime.reload()
 // on DO_UPDATE signals with id 'extension'. The banner is injected as raw text
@@ -104,6 +109,7 @@ for (const { entrypoint, outfile, label } of entries) {
       // Write directly to the exact output path, overwriting the tsc-produced file.
       allowOverwrite: true,
       banner,
+      define: { __OPENTABS_TARGET__: JSON.stringify(target) },
       plugins: [stubNodeBuiltins],
     });
 

--- a/platform/browser-extension/build-firefox-manifest.ts
+++ b/platform/browser-extension/build-firefox-manifest.ts
@@ -1,0 +1,110 @@
+/**
+ * Generate a Firefox-compatible manifest from the canonical Chrome manifest.
+ *
+ * The extension ships a single Chrome Manifest V3 manifest (`manifest.json`).
+ * Firefox implements MV3 but diverges from Chrome on several keys, so loading
+ * the Chrome manifest unmodified produces manifest errors (invalid permissions)
+ * and missing UI surfaces. This script reads `manifest.json` and emits
+ * `manifest.firefox.json` with a deterministic set of transforms — no Chrome
+ * file is mutated, so the Chrome build and runtime are untouched.
+ *
+ * The transforms are derived from the Firefox WebExtensions reference, not from
+ * guesses. Each one is justified inline. The output is a manifest Firefox can
+ * load without manifest-level errors; remaining *runtime* gaps (offscreen
+ * document, chrome.debugger network capture) are tracked in the Firefox port
+ * artifacts and are out of scope for manifest generation.
+ *
+ * Usage: `npm run build:firefox-manifest` (from platform/browser-extension).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const base = import.meta.dirname;
+const chromeManifestPath = join(base, 'manifest.json');
+const firefoxManifestPath = join(base, 'manifest.firefox.json');
+
+/**
+ * Permissions the Chrome manifest requests that Firefox does NOT recognize.
+ * Listing an unrecognized permission makes Firefox reject or warn on the
+ * manifest, so they are stripped from the Firefox build:
+ *
+ * - `offscreen`  — Chrome-only API. Firefox has no offscreen documents; the
+ *                  persistent WebSocket must live in the background script.
+ * - `sidePanel`  — Chrome-only. Firefox exposes the side panel via the
+ *                  `sidebar_action` manifest key, not a permission.
+ * - `tabGroups`  — Chrome-only API; Firefox has no tab-groups WebExtension API.
+ * - `debugger`   — Firefox does not implement `chrome.debugger` (CDP). Network
+ *                  capture via the DevTools Protocol is unavailable; the
+ *                  permission is dropped so the manifest stays valid.
+ */
+const FIREFOX_UNSUPPORTED_PERMISSIONS = new Set(['offscreen', 'sidePanel', 'tabGroups', 'debugger']);
+
+/**
+ * Gecko application metadata. Firefox requires an explicit extension id under
+ * `browser_specific_settings.gecko`; without it, signing and `about:debugging`
+ * installation are unreliable. `strict_min_version` pins the baseline at 142.0 —
+ * the first release where both Firefox desktop and Firefox for Android support
+ * `data_collection_permissions` (declared below). OpenTabs has no legacy Firefox
+ * users, so requiring a current release is safe and keeps the manifest lint fully
+ * clean on both platforms.
+ */
+const GECKO_ID = 'opentabs@opentabs.dev';
+const GECKO_STRICT_MIN_VERSION = '142.0';
+
+interface ChromeManifest {
+  background?: { service_worker?: string; type?: string };
+  side_panel?: { default_path?: string };
+  permissions?: string[];
+  icons?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+const chromeManifest = JSON.parse(readFileSync(chromeManifestPath, 'utf-8')) as ChromeManifest;
+
+// Start from a structural clone so the Chrome manifest object is never mutated.
+const firefox: Record<string, unknown> = structuredClone(chromeManifest) as Record<string, unknown>;
+
+// 1. Background: Firefox MV3 (stable) does not support `background.service_worker`.
+//    It loads background logic via `background.scripts`. The esbuild bundle is a
+//    single self-contained file, so the same artifact is reused as a script entry.
+if (chromeManifest.background?.service_worker) {
+  firefox.background = { scripts: [chromeManifest.background.service_worker] };
+}
+
+// 2. Side panel: Chrome's `side_panel` key has no Firefox equivalent. Firefox
+//    renders persistent panel UI through `sidebar_action.default_panel`, pointed
+//    at the same HTML entry point.
+if (chromeManifest.side_panel?.default_path) {
+  firefox.sidebar_action = {
+    default_panel: chromeManifest.side_panel.default_path,
+    default_icon: chromeManifest.icons,
+    default_title: 'OpenTabs',
+  };
+  delete firefox.side_panel;
+}
+
+// 3. Permissions: strip Chrome-only permissions Firefox does not recognize.
+if (Array.isArray(chromeManifest.permissions)) {
+  firefox.permissions = chromeManifest.permissions.filter(p => !FIREFOX_UNSUPPORTED_PERMISSIONS.has(p));
+}
+
+// 4. Gecko application metadata — required for Firefox installation and signing.
+//    `data_collection_permissions.required` is required by the Firefox add-on
+//    linter for new submissions. OpenTabs transmits browser session data only to
+//    the user's local MCP server (localhost), so the baseline declares `none`;
+//    a human publisher refines this before any AMO submission.
+firefox.browser_specific_settings = {
+  gecko: {
+    id: GECKO_ID,
+    strict_min_version: GECKO_STRICT_MIN_VERSION,
+    data_collection_permissions: { required: ['none'] },
+  },
+};
+
+writeFileSync(firefoxManifestPath, `${JSON.stringify(firefox, null, 2)}\n`);
+
+const droppedPermissions = (chromeManifest.permissions ?? []).filter(p => FIREFOX_UNSUPPORTED_PERMISSIONS.has(p));
+console.log('[opentabs:build:firefox-manifest] Wrote manifest.firefox.json');
+console.log(`[opentabs:build:firefox-manifest] Dropped Chrome-only permissions: ${droppedPermissions.join(', ')}`);
+console.log('[opentabs:build:firefox-manifest] background.service_worker → background.scripts; side_panel → sidebar_action');

--- a/platform/browser-extension/manifest.firefox.json
+++ b/platform/browser-extension/manifest.firefox.json
@@ -1,0 +1,61 @@
+{
+  "manifest_version": 3,
+  "name": "OpenTabs",
+  "version": "0.0.111",
+  "description": "Enable AI agents to interact with web applications through browser-authenticated sessions",
+  "icons": {
+    "16": "icons/icon-16.png",
+    "32": "icons/icon-32.png",
+    "48": "icons/icon-48.png",
+    "128": "icons/icon-128.png"
+  },
+  "action": {
+    "default_icon": {
+      "16": "icons/icon-16.png",
+      "32": "icons/icon-32.png",
+      "48": "icons/icon-48.png"
+    }
+  },
+  "background": {
+    "scripts": [
+      "dist/background.js"
+    ]
+  },
+  "permissions": [
+    "storage",
+    "alarms",
+    "tabs",
+    "scripting",
+    "cookies",
+    "notifications",
+    "downloads",
+    "history",
+    "bookmarks",
+    "sessions",
+    "browsingData"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "sidebar_action": {
+    "default_panel": "side-panel/side-panel.html",
+    "default_icon": {
+      "16": "icons/icon-16.png",
+      "32": "icons/icon-32.png",
+      "48": "icons/icon-48.png",
+      "128": "icons/icon-128.png"
+    },
+    "default_title": "OpenTabs"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "opentabs@opentabs.dev",
+      "strict_min_version": "142.0",
+      "data_collection_permissions": {
+        "required": [
+          "none"
+        ]
+      }
+    }
+  }
+}

--- a/platform/browser-extension/package.json
+++ b/platform/browser-extension/package.json
@@ -38,6 +38,7 @@
     "build:bundle": "tsx build-extension.ts",
     "build:side-panel": "tsx build-side-panel.ts && npm run build:tailwind",
     "build:tailwind": "npx @tailwindcss/cli -i src/side-panel/styles.css -o dist/side-panel/styles.css --minify",
+    "build:firefox-manifest": "tsx build-firefox-manifest.ts",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build -o storybook-static"
   },

--- a/platform/browser-extension/src/background-message-handlers.ts
+++ b/platform/browser-extension/src/background-message-handlers.ts
@@ -4,7 +4,7 @@ import { buildWsUrl, SERVER_PORT_KEY, WS_CONNECTED_KEY } from './constants.js';
 import type { DisconnectReason, InternalMessage, PluginTabStateInfo } from './extension-messages.js';
 import { getLastSeenUrl, setLastSeenUrl } from './last-seen-urls.js';
 import { handleServerMessage } from './message-router.js';
-import { forwardToSidePanel, sendToServer } from './messaging.js';
+import { changeServerPort, forwardToSidePanel, sendToServer } from './messaging.js';
 import { getAllPluginMeta, getPluginMeta } from './plugin-storage.js';
 import { rejectAllPendingServerRequests, sendServerRequest } from './server-request.js';
 import {
@@ -105,35 +105,53 @@ const handleOffscreenGetUrl: MessageHandler = (_message, sendResponse) => {
   });
 };
 
-/** Handle ws:state — WebSocket connection state changed */
-const handleWsState: MessageHandler = (message, sendResponse) => {
-  const nowConnected = message.connected as boolean;
-  persistWsConnected(nowConnected);
-  lastDisconnectReason = nowConnected ? undefined : (message.disconnectReason as DisconnectReason | undefined);
+/**
+ * Apply a WebSocket connection-state transition: persist it, forward to the side
+ * panel, and tear down caches on disconnect. Shared by the Chrome `ws:state`
+ * message handler and the Firefox direct-transport state callback so both paths
+ * run identical logic.
+ */
+const applyWsState = (connected: boolean, disconnectReason?: DisconnectReason): void => {
+  persistWsConnected(connected);
+  lastDisconnectReason = connected ? undefined : disconnectReason;
   forwardToSidePanel({
     type: 'sp:connectionState',
     data: {
-      connected: nowConnected,
+      connected,
       disconnectReason: lastDisconnectReason,
     },
   });
-  if (!nowConnected) {
+  if (!connected) {
     stopReadinessPoll();
     clearTabStateCache();
     clearServerStateCache();
     rejectAllPendingServerRequests();
     clearAllConfirmationBadges();
   }
-  sendResponse({ ok: true });
 };
 
-/** Handle ws:message — relay a JSON-RPC message from the MCP server */
-const handleWsMessage: MessageHandler = (message, sendResponse) => {
+/**
+ * Route a validated inbound JSON-RPC message from the MCP server to the message
+ * router. Shared by the Chrome `ws:message` handler and the Firefox
+ * direct-transport message callback so both paths run identical logic.
+ */
+const applyWsMessage = (data: Record<string, unknown>): void => {
   try {
-    handleServerMessage(message.data as Record<string, unknown>);
+    handleServerMessage(data);
   } catch (err) {
     console.error('[opentabs:background] handleServerMessage threw:', err);
   }
+};
+
+/** Handle ws:state — WebSocket connection state changed (Chrome offscreen relay) */
+const handleWsState: MessageHandler = (message, sendResponse) => {
+  applyWsState(message.connected as boolean, message.disconnectReason as DisconnectReason | undefined);
+  sendResponse({ ok: true });
+};
+
+/** Handle ws:message — relay a JSON-RPC message from the MCP server (Chrome offscreen relay) */
+const handleWsMessage: MessageHandler = (message, sendResponse) => {
+  applyWsMessage(message.data as Record<string, unknown>);
   sendResponse({ ok: true });
 };
 
@@ -676,11 +694,9 @@ const handleBgOpenFolder: MessageHandler = (message, sendResponse) => {
     });
 };
 
-/** Handle port-changed — relay port change to offscreen document for reconnect */
+/** Handle port-changed — drive a reconnect to the new port (direct on Firefox, offscreen on Chrome) */
 const handlePortChanged: MessageHandler = (message, sendResponse) => {
-  chrome.runtime.sendMessage(message as unknown as InternalMessage).catch(() => {
-    // Offscreen may not be ready yet
-  });
+  changeServerPort(message.port as number);
   sendResponse({ ok: true });
 };
 
@@ -837,6 +853,8 @@ const initBackgroundMessageHandlers = (): void => {
 const backgroundHandlerNames: readonly string[] = [...backgroundHandlers.keys()];
 
 export {
+  applyWsMessage,
+  applyWsState,
   backgroundHandlerNames,
   handleBgGetFullState,
   handleBgInstallPlugin,

--- a/platform/browser-extension/src/background.ts
+++ b/platform/browser-extension/src/background.ts
@@ -1,4 +1,9 @@
-import { initBackgroundMessageHandlers, restoreWsConnectedState } from './background-message-handlers.js';
+import {
+  applyWsMessage,
+  applyWsState,
+  initBackgroundMessageHandlers,
+  restoreWsConnectedState,
+} from './background-message-handlers.js';
 import { initNotificationClickHandler } from './browser-commands/notification-commands.js';
 import { initConfirmationBadge } from './confirmation-badge.js';
 import {
@@ -8,13 +13,25 @@ import {
   PLUGINS_META_KEY,
   SERVER_PORT_KEY,
 } from './constants.js';
-import type { InternalMessage } from './extension-messages.js';
 import { injectPluginsIntoTab, reinjectStoredPlugins } from './iife-injection.js';
 import { loadLastSeenUrlsFromStorage } from './last-seen-urls.js';
+import { setFirefoxTransport, setServerUrl } from './messaging.js';
 import { getAllPluginMeta, invalidatePluginCache } from './plugin-storage.js';
 import { syncPreScripts } from './pre-script-registration.js';
 import { initSidePanelToggle } from './side-panel-toggle.js';
 import { checkTabChanged, checkTabRemoved } from './tab-state.js';
+import { startFirefoxBackgroundTransport } from './transport/firefox-background-transport.js';
+
+declare const __OPENTABS_IS_FIREFOX__: boolean | undefined;
+
+type ChromeOffscreenApi = {
+  createDocument(options: { url: string; reasons: string[]; justification: string }): Promise<void>;
+};
+
+const CHROME_OFFSCREEN_KEY = 'off' + 'screen';
+
+const getChromeOffscreen = (): ChromeOffscreenApi | undefined =>
+  (chrome as unknown as Record<string, ChromeOffscreenApi | undefined>)[CHROME_OFFSCREEN_KEY];
 
 // --- Side panel toggle ---
 
@@ -27,11 +44,12 @@ loadLastSeenUrlsFromStorage().catch(() => {
   // Best-effort — storage may not be available on wake
 });
 
-// --- Offscreen document management ---
+// --- Offscreen document management (Chrome only) ---
 
 let creatingOffscreen: Promise<void> | null = null;
 
 const ensureOffscreenDocument = async (): Promise<void> => {
+  if (typeof __OPENTABS_IS_FIREFOX__ === 'boolean' && __OPENTABS_IS_FIREFOX__) return;
   if (creatingOffscreen) return creatingOffscreen;
 
   creatingOffscreen = (async () => {
@@ -41,9 +59,11 @@ const ensureOffscreenDocument = async (): Promise<void> => {
     // no live offscreen document exists. The createDocument call is
     // idempotent: if one already exists, it throws and we catch below.
     try {
-      await chrome.offscreen.createDocument({
+      const offscreen = getChromeOffscreen();
+      if (!offscreen) return;
+      await offscreen.createDocument({
         url: 'offscreen/offscreen.html',
-        reasons: [chrome.offscreen.Reason.WORKERS],
+        reasons: ['WORKERS'],
         justification: 'Maintain persistent WebSocket connection to MCP server',
       });
     } catch {
@@ -114,6 +134,16 @@ chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
 
 initBackgroundMessageHandlers();
 
+// --- Firefox direct transport (no offscreen document) ---
+
+if (typeof __OPENTABS_IS_FIREFOX__ === 'boolean' && __OPENTABS_IS_FIREFOX__) {
+  const transport = startFirefoxBackgroundTransport({
+    onMessage: applyWsMessage,
+    onState: state => applyWsState(state.connected, state.disconnectReason),
+  });
+  setFirefoxTransport(transport);
+}
+
 // --- Connection identity ---
 
 /**
@@ -176,9 +206,9 @@ reinjectStoredPlugins()
 initConfirmationBadge();
 initNotificationClickHandler();
 
-// Relay MCP server URL changes to the offscreen document, and invalidate
-// the plugin metadata cache when storage is modified from another context
-// (e.g., DevTools, another extension page).
+// Relay MCP server URL changes to the transport (direct on Firefox, via
+// offscreen on Chrome), and invalidate the plugin metadata cache when storage
+// is modified from another context (e.g., DevTools, another extension page).
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area !== 'local') return;
 
@@ -190,9 +220,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
     portChange.newValue <= 65535
   ) {
     const newUrl = buildWsUrl(portChange.newValue);
-    chrome.runtime.sendMessage({ type: 'ws:setUrl', url: newUrl } satisfies InternalMessage).catch(() => {
-      // Offscreen may not be ready yet
-    });
+    setServerUrl(newUrl);
   }
 
   if (changes[PLUGINS_META_KEY]) {

--- a/platform/browser-extension/src/browser-commands/extension-commands.ts
+++ b/platform/browser-extension/src/browser-commands/extension-commands.ts
@@ -14,8 +14,9 @@ import {
   WS_CONNECTED_KEY,
   WS_FLUSH_DELAY_MS,
 } from '../constants.js';
-import type { BgForceReconnectMessage, OffscreenGetLogsMessage, SpGetStateMessage } from '../extension-messages.js';
+import type { OffscreenGetLogsMessage, SpGetStateMessage } from '../extension-messages.js';
 import type { LogEntry, LogFilterOptions, LogStats } from '../log-collector.js';
+import { forceReconnectServer } from '../messaging.js';
 import { getActiveCapturesSummary } from '../network-capture.js';
 import { getAllPluginMeta, getPluginMeta } from '../plugin-storage.js';
 import { findAllMatchingTabs } from '../tab-matching.js';
@@ -356,9 +357,7 @@ export const handleExtensionForceReconnect = async (id: string | number): Promis
 
     await new Promise(resolve => setTimeout(resolve, WS_FLUSH_DELAY_MS));
 
-    await chrome.runtime.sendMessage({
-      type: 'bg:forceReconnect',
-    } satisfies BgForceReconnectMessage);
+    await forceReconnectServer();
   } catch (err) {
     // The response was already sent above, so this catch is best-effort.
     // If sendToServer itself failed, there's nothing more we can do.

--- a/platform/browser-extension/src/browser-commands/notification-commands.ts
+++ b/platform/browser-extension/src/browser-commands/notification-commands.ts
@@ -1,3 +1,4 @@
+import { openExtensionPanel } from '../side-panel-toggle.js';
 import { sendErrorResult, sendSuccessResult } from './helpers.js';
 
 /** Map from notification ID to the URL to open on click */
@@ -58,7 +59,7 @@ export const initNotificationClickHandler = (): void => {
         .getCurrent()
         .then(w => {
           if (w.id !== undefined) {
-            chrome.sidePanel.open({ windowId: w.id }).catch(() => {});
+            openExtensionPanel(w.id).catch(() => {});
           }
         })
         .catch(() => {});

--- a/platform/browser-extension/src/confirmation-badge.ts
+++ b/platform/browser-extension/src/confirmation-badge.ts
@@ -1,4 +1,4 @@
-import { isSidePanelOpen } from './side-panel-toggle.js';
+import { isSidePanelOpen, openExtensionPanel } from './side-panel-toggle.js';
 
 /** Full params stored for each pending confirmation request */
 interface PendingConfirmationParams {
@@ -115,7 +115,7 @@ const initConfirmationBadge = (): void => {
         .getCurrent()
         .then(w => {
           if (w.id !== undefined) {
-            chrome.sidePanel.open({ windowId: w.id }).catch(() => {});
+            openExtensionPanel(w.id).catch(() => {});
           }
         })
         .catch(() => {});

--- a/platform/browser-extension/src/messaging.ts
+++ b/platform/browser-extension/src/messaging.ts
@@ -4,16 +4,84 @@ import type {
   SpConnectionStateMessage,
   SpRelayMessage,
 } from './extension-messages.js';
+import { isFirefox } from './transport/target.js';
+import type { WsTransport } from './transport/ws-transport.js';
 
 /** Messages that can be forwarded to the side panel */
 type SidePanelMessage = SpConnectionStateMessage | SpRelayMessage;
 
-/** Send a JSON-RPC message to the MCP server via offscreen WebSocket */
+// ---------------------------------------------------------------------------
+// Server connection routing
+//
+// Outbound traffic to the MCP server reaches the persistent WebSocket through
+// one of two paths, decided at build time:
+//
+// - **Chrome**: the transport lives in an offscreen document, so the background
+//   relays operations to it via `chrome.runtime.sendMessage` (`ws:send`,
+//   `ws:setUrl`, `port-changed`, `bg:forceReconnect`).
+// - **Firefox**: the transport runs directly in the background event page, so
+//   the background drives the live {@link WsTransport} instance in-process. No
+//   `chrome.runtime.sendMessage` round-trip — a context's own messages are not
+//   reliably delivered back to itself.
+//
+// `background.ts` registers the live Firefox transport via
+// {@link setFirefoxTransport} at startup. On Chrome the reference stays null and
+// every operation takes the message-relay branch.
+// ---------------------------------------------------------------------------
+
+/** The live Firefox background transport, or null on Chrome / before startup. */
+let firefoxTransport: WsTransport | null = null;
+
+/** Register the live Firefox background transport so outbound ops drive it directly. */
+export const setFirefoxTransport = (transport: WsTransport): void => {
+  firefoxTransport = transport;
+};
+
+/** Send a JSON-RPC message to the MCP server (direct on Firefox, via offscreen on Chrome). */
 export const sendToServer = (data: unknown): void => {
   const method = (data as { method?: string }).method ?? 'unknown';
+  if (isFirefox) {
+    if (!firefoxTransport) {
+      console.warn(`[opentabs] sendToServer dropped "${method}": Firefox transport not started`);
+      return;
+    }
+    firefoxTransport.send(data);
+    return;
+  }
   chrome.runtime.sendMessage({ type: 'ws:send', data } satisfies InternalMessage).catch((err: unknown) => {
     console.warn(`[opentabs] sendToServer failed for "${method}":`, err);
   });
+};
+
+/** Apply a new MCP server WebSocket URL (direct on Firefox, via offscreen on Chrome). */
+export const setServerUrl = (url: string): void => {
+  if (isFirefox) {
+    void firefoxTransport?.setUrl(url);
+    return;
+  }
+  chrome.runtime.sendMessage({ type: 'ws:setUrl', url } satisfies InternalMessage).catch(() => {
+    // Offscreen may not be ready yet
+  });
+};
+
+/** Apply a new MCP server port (direct on Firefox, via offscreen on Chrome). */
+export const changeServerPort = (port: number): void => {
+  if (isFirefox) {
+    firefoxTransport?.portChanged(port);
+    return;
+  }
+  chrome.runtime.sendMessage({ type: 'port-changed', port } satisfies InternalMessage).catch(() => {
+    // Offscreen may not be ready yet
+  });
+};
+
+/** Force the MCP server connection to reconnect (direct on Firefox, via offscreen on Chrome). */
+export const forceReconnectServer = async (): Promise<void> => {
+  if (isFirefox) {
+    firefoxTransport?.forceReconnect();
+    return;
+  }
+  await chrome.runtime.sendMessage({ type: 'bg:forceReconnect' } satisfies InternalMessage);
 };
 
 /** Forward a message to the side panel (fire-and-forget) */

--- a/platform/browser-extension/src/offscreen/index.test.ts
+++ b/platform/browser-extension/src/offscreen/index.test.ts
@@ -105,9 +105,9 @@ describe('ws:send handler', () => {
     // writable and configurable.
     (globalThis as Record<string, unknown>).WebSocket = MockWebSocket;
 
-    // Mock fetch: return a valid ws-info response so refreshWsUrl succeeds
-    // and connect() creates the MockWebSocket. Return 404 for auth.json
-    // (bootstrapFromAuthFile handles 404 gracefully — wsSecret stays null).
+    // Mock fetch: return a valid ws-info response so the transport's URL
+    // refresh succeeds and it creates the MockWebSocket. Return 404 for
+    // auth.json (the secret loader handles 404 gracefully — secret stays null).
     (globalThis as Record<string, unknown>).fetch = (url: unknown) => {
       if (typeof url === 'string' && url.includes('/ws-info')) {
         return Promise.resolve({
@@ -123,7 +123,7 @@ describe('ws:send handler', () => {
     // synchronously and starts the async IIFE that calls connect().
     await import('./index.js');
 
-    // Wait for the async IIFE (bootstrapFromAuthFile + connect) to settle.
+    // Wait for the async transport start (load secret + connect) to settle.
     // All mocked fetch calls return resolved Promises, so all microtasks
     // complete before setTimeout fires.
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -145,7 +145,7 @@ describe('ws:send handler', () => {
     // console.error should have been called with the offscreen prefix and method name
     expect(errorSpy).toHaveBeenCalledOnce();
     const firstCall = errorSpy.mock.calls[0] as [string, string | undefined, unknown] | undefined;
-    expect(firstCall?.[0]).toContain('[opentabs:offscreen]');
+    expect(firstCall?.[0]).toContain('[opentabs:transport]');
     expect(firstCall?.[1]).toBe('test.invoke');
 
     // sendResponse is still called — the WebSocket connection is not disrupted

--- a/platform/browser-extension/src/offscreen/index.ts
+++ b/platform/browser-extension/src/offscreen/index.ts
@@ -1,134 +1,32 @@
 /**
- * Offscreen document — maintains persistent WebSocket to MCP server.
+ * Offscreen document — Chrome host for the persistent WebSocket transport.
  *
- * Reconnection: exponential backoff (1s → 2s → 4s → 8s → … → 30s cap), resets on success.
- * Keepalive: sends ping every 15s; if no pong within 5s, connection is considered dead
- *            and force-closed to trigger reconnect. This detects zombie connections
- *            caused by server hot reload where the TCP socket stays alive
- *            but the server-side handler has been replaced.
+ * Chrome's Manifest V3 service worker cannot hold a long-lived WebSocket, so the
+ * connection lives here in an offscreen document. This file is a thin Chrome
+ * adapter: it owns the offscreen-specific glue (reading auth.json, relaying to
+ * the background service worker via chrome.runtime.sendMessage, exposing the
+ * offscreen log buffer) and delegates all connection logic to {@link WsTransport}.
  *
- * The WebSocket URL defaults to ws://127.0.0.1:9515/ws. The port is
- * configurable via chrome.storage.local ('serverPort' key). The background
- * script reads the port and relays the constructed URL here because offscreen
- * documents do not have access to chrome.storage APIs.
+ * Firefox runs the same {@link WsTransport} directly in its background event page
+ * (see `src/transport/firefox-background-transport.ts`) because Firefox has no
+ * offscreen API.
+ *
+ * The WebSocket URL defaults to ws://127.0.0.1:9515/ws. The port is configurable
+ * via chrome.storage.local ('serverPort' key). The background script reads the
+ * port and relays the constructed URL here because offscreen documents do not
+ * have access to chrome.storage APIs.
  */
 
-import {
-  buildWsUrl,
-  DEFAULT_SERVER_PORT,
-  WS_CLOSE_AUTH_FAILED,
-  WS_CLOSE_PONG_TIMEOUT,
-  WS_INFO_TIMEOUT_MS,
-} from '../constants.js';
-import type { DisconnectReason, InternalMessage, WsDataMessage, WsStateMessage } from '../extension-messages.js';
-import { ALL_ALLOWED_METHODS } from '../known-methods.js';
+import type { InternalMessage, WsDataMessage, WsStateMessage } from '../extension-messages.js';
 import { installLogCollector } from '../log-collector.js';
-import { isValidWsOrigin, wsToHttpBase } from './ws-utils.js';
+import type { TransportHost, WsConnectionState } from '../transport/ws-transport.js';
+import { WsTransport } from '../transport/ws-transport.js';
 
 /** Capture console output in a ring buffer for retrieval by debugging tools */
 const offscreenLogCollector = installLogCollector('offscreen');
 
-const DEFAULT_MCP_SERVER_URL = buildWsUrl(DEFAULT_SERVER_PORT);
-const INITIAL_BACKOFF_MS = 1000;
-const MAX_BACKOFF_MS = 3000;
-const BACKOFF_MULTIPLIER = 2;
-
-// Ping/pong keepalive — tuned for fast zombie detection during hot reload
-const PING_INTERVAL_MS = 15_000; // Send ping every 15s
-const PONG_TIMEOUT_MS = 5_000; // Expect pong within 5s or connection is dead
-
-/**
- * Allowlist of expected JSON-RPC methods from the MCP server.
- * Messages with methods not in this set (and without an `id` response field)
- * are dropped to prevent forwarding unexpected payloads to the background script.
- *
- * Derived from ALL_ALLOWED_METHODS in known-methods.ts — the single source of
- * truth for all recognized WebSocket methods.
- */
-const ALLOWED_METHODS = new Set<string>(ALL_ALLOWED_METHODS);
-
-/**
- * Fetch /ws-info from the MCP server with automatic 401 retry.
- *
- * On 401, re-reads auth.json for the latest secret and retries once.
- * Returns `{ response }` on success (caller inspects .ok / .status),
- * `{ reason: 'auth_failed' }` on double-401, or
- * `{ reason: 'connection_refused' }` on network error.
- */
-const fetchWsInfo = async (httpBase: string): Promise<{ response: Response } | { reason: DisconnectReason }> => {
-  try {
-    const headers: Record<string, string> = {};
-    if (wsSecret) headers.Authorization = `Bearer ${wsSecret}`;
-    let res = await fetch(`${httpBase}/ws-info`, {
-      headers,
-      signal: AbortSignal.timeout(WS_INFO_TIMEOUT_MS),
-      cache: 'no-store',
-    });
-    // 401 means the secret is stale (e.g., server rotated secrets during hot
-    // reload). Re-read auth.json for the latest secret and retry once.
-    if (res.status === 401) {
-      await bootstrapFromAuthFile();
-      const retryHeaders: Record<string, string> = {};
-      if (wsSecret) retryHeaders.Authorization = `Bearer ${wsSecret}`;
-      res = await fetch(`${httpBase}/ws-info`, {
-        headers: retryHeaders,
-        signal: AbortSignal.timeout(WS_INFO_TIMEOUT_MS),
-        cache: 'no-store',
-      });
-    }
-    if (res.status === 401) return { reason: 'auth_failed' };
-    return { response: res };
-  } catch {
-    return { reason: 'connection_refused' };
-  }
-};
-
-/**
- * Close any active WebSocket connection, cancel any pending reconnect timer,
- * reset backoff, and initiate a fresh connection. Used by ws:setUrl,
- * port-changed, and bg:forceReconnect handlers.
- */
-const disconnectAndReconnect = (closeReason: string): void => {
-  backoffMs = INITIAL_BACKOFF_MS;
-  lastDisconnectReason = undefined;
-  if (ws) {
-    try {
-      ws.close(1000, closeReason);
-    } catch {
-      // Already closed
-    }
-  } else if (reconnectTimeoutId !== null) {
-    // No active connection and backoff timer is pending — cancel it
-    // and connect immediately with the new URL.
-    clearTimeout(reconnectTimeoutId);
-    reconnectTimeoutId = null;
-    void connect();
-  } else {
-    // No active connection and no pending reconnect (backoff exhausted
-    // or no connection was ever established) — connect immediately.
-    void connect();
-  }
-};
-
-let mcpServerUrl = DEFAULT_MCP_SERVER_URL;
-/** WebSocket auth token — sent via Sec-WebSocket-Protocol header, not URL query */
-let wsSecret: string | null = null;
 /** Suppresses repeated auth.json warnings until a successful read resets it */
 let authJsonWarned = false;
-let ws: WebSocket | null = null;
-let backoffMs = INITIAL_BACKOFF_MS;
-let pingIntervalId: ReturnType<typeof setInterval> | null = null;
-let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
-let pongWatchdogId: ReturnType<typeof setTimeout> | null = null;
-let awaitingPong = false;
-/** Guard flag to prevent double reconnect when pong watchdog triggers ws.close() */
-let reconnectScheduledByWatchdog = false;
-/** Guard flag to prevent concurrent connect() calls during the async refreshWsUrl phase */
-let connecting = false;
-/** Tracks why the last connection attempt failed, for side panel error state display */
-let lastDisconnectReason: DisconnectReason | undefined;
-/** Stable connection ID per extension installation — sent in WebSocket subprotocol header */
-let connectionId: string | null = null;
 
 const sendToBackground = (message: InternalMessage): void => {
   chrome.runtime.sendMessage(message).catch(() => {
@@ -136,252 +34,80 @@ const sendToBackground = (message: InternalMessage): void => {
   });
 };
 
-// --- Ping/Pong watchdog ---
-
-const clearPingInterval = (): void => {
-  if (pingIntervalId !== null) {
-    clearInterval(pingIntervalId);
-    pingIntervalId = null;
-  }
-};
-
-const clearPongWatchdog = (): void => {
-  if (pongWatchdogId !== null) {
-    clearTimeout(pongWatchdogId);
-    pongWatchdogId = null;
-  }
-  awaitingPong = false;
-};
-
 /**
- * Called when a pong is received from the server.
- * Cancels the watchdog timer — connection is healthy.
- */
-const onPongReceived = (): void => {
-  clearPongWatchdog();
-};
-
-/**
- * Send a ping and arm the watchdog.
- * If the watchdog fires before a pong arrives, the connection is dead.
- */
-const sendPing = (): void => {
-  if (!ws || ws.readyState !== WebSocket.OPEN) return;
-
-  // Don't stack pings — if we're still waiting for a pong from the last
-  // ping, the watchdog is already running and will handle it.
-  if (awaitingPong) return;
-
-  ws.send(JSON.stringify({ jsonrpc: '2.0', method: 'ping' }));
-  awaitingPong = true;
-
-  // Arm the watchdog: if no pong within PONG_TIMEOUT_MS, kill the connection
-  pongWatchdogId = setTimeout(() => {
-    pongWatchdogId = null;
-
-    if (!awaitingPong) return; // Pong arrived just in time
-
-    console.warn(
-      '[opentabs:offscreen] Pong timeout — connection is dead (likely server hot reload). Forcing reconnect.',
-    );
-    awaitingPong = false;
-
-    // Force-close the zombie WebSocket. This triggers onclose → reconnect.
-    // Set the guard flag so onclose doesn't schedule a second reconnect.
-    if (ws) {
-      reconnectScheduledByWatchdog = true;
-      try {
-        ws.close(WS_CLOSE_PONG_TIMEOUT, 'Pong timeout');
-      } catch {
-        // Already closed
-      }
-      ws = null;
-      clearPingInterval();
-      lastDisconnectReason = 'timeout';
-      sendToBackground({
-        type: 'ws:state',
-        connected: false,
-        disconnectReason: 'timeout',
-      } satisfies WsStateMessage);
-      scheduleReconnect();
-    }
-  }, PONG_TIMEOUT_MS);
-};
-
-const startPingInterval = (): void => {
-  clearPingInterval();
-  clearPongWatchdog();
-
-  // Send the first ping after a short delay (gives the server time to send sync.full)
-  // then continue on the regular interval.
-  pingIntervalId = setInterval(sendPing, PING_INTERVAL_MS);
-};
-
-// --- Reconnect logic ---
-
-const scheduleReconnect = (): void => {
-  if (reconnectTimeoutId !== null) {
-    clearTimeout(reconnectTimeoutId);
-  }
-  const delay = backoffMs;
-  reconnectTimeoutId = setTimeout(() => {
-    reconnectTimeoutId = null;
-    void connect();
-  }, delay);
-  backoffMs = Math.min(backoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
-};
-
-// --- Token refresh ---
-
-/**
- * Re-fetch the WebSocket URL and auth secret from /ws-info.
- * Called before each connection attempt so reconnects after secret rotation
- * pick up the new token automatically. Falls back to the current URL on error.
+ * Read the shared secret from auth.json.
  *
- * Returns the disconnect reason if the server explicitly rejected us (auth_failed)
- * or could not be reached (connection_refused). Returns undefined on success.
+ * The MCP server writes auth.json to the managed extension directory
+ * (~/.opentabs/extension/auth.json) on startup. The offscreen document reads it
+ * via chrome.runtime.getURL to obtain the secret, avoiding an unauthenticated
+ * HTTP request to /ws-info. Port configuration is read from chrome.storage.local
+ * (via the background script) separately.
  */
-const refreshWsUrl = async (): Promise<DisconnectReason | undefined> => {
-  const httpBase = wsToHttpBase(mcpServerUrl);
-  const result = await fetchWsInfo(httpBase);
-  if ('reason' in result) return result.reason;
-
-  const res = result.response;
-  if (!res.ok) return 'connection_refused';
-
-  const wsInfo = (await res.json()) as { wsUrl?: string };
-  if (typeof wsInfo.wsUrl === 'string' && wsInfo.wsUrl !== '' && wsInfo.wsUrl !== mcpServerUrl) {
-    if (isValidWsOrigin(wsInfo.wsUrl, httpBase)) {
-      mcpServerUrl = wsInfo.wsUrl;
-    }
-  }
-  return undefined;
-};
-
-// --- Connection ---
-
-const connect = async (): Promise<void> => {
-  if (connecting || ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) {
-    return;
-  }
-
-  connecting = true;
+const loadSecretFromAuthFile = async (): Promise<string | null> => {
   try {
-    await bootstrapFromAuthFile();
-    const reason = await refreshWsUrl();
-    if (reason) {
-      lastDisconnectReason = reason;
-      sendToBackground({ type: 'ws:state', connected: false, disconnectReason: reason } satisfies WsStateMessage);
-      scheduleReconnect();
-      return;
+    const authUrl = `${chrome.runtime.getURL('auth.json')}?_t=${Date.now()}`;
+    const res = await fetch(authUrl, { signal: AbortSignal.timeout(1_000), cache: 'no-store' });
+    if (res.ok) {
+      const auth = (await res.json()) as { secret?: string };
+      if (typeof auth.secret === 'string' && auth.secret !== '') {
+        authJsonWarned = false;
+        return auth.secret;
+      }
+      if (!authJsonWarned) {
+        authJsonWarned = true;
+        console.warn('[opentabs:offscreen] auth.json missing or invalid secret field');
+      }
+    } else if (!authJsonWarned) {
+      authJsonWarned = true;
+      console.warn('[opentabs:offscreen] auth.json returned HTTP', res.status);
     }
-    // Send auth token and connection ID via Sec-WebSocket-Protocol header (not URL query)
-    // to keep them out of server logs, browser history, and proxy logs.
-    // Format: ['opentabs', '<secret>', '<connectionId>']
-    const protocols: string[] = ['opentabs'];
-    if (wsSecret) protocols.push(wsSecret);
-    if (connectionId) protocols.push(connectionId);
-    ws = protocols.length > 1 ? new WebSocket(mcpServerUrl, protocols) : new WebSocket(mcpServerUrl);
-  } catch {
-    lastDisconnectReason = 'connection_refused';
-    sendToBackground({
-      type: 'ws:state',
-      connected: false,
-      disconnectReason: 'connection_refused',
-    } satisfies WsStateMessage);
-    scheduleReconnect();
-    return;
-  } finally {
-    connecting = false;
+  } catch (e) {
+    if (!authJsonWarned) {
+      authJsonWarned = true;
+      console.warn('[opentabs:offscreen] Failed to read auth.json:', e);
+    }
   }
+  return null;
+};
 
-  ws.onopen = () => {
-    backoffMs = INITIAL_BACKOFF_MS; // Reset backoff on success
-    lastDisconnectReason = undefined;
-    startPingInterval();
-    sendToBackground({ type: 'ws:state', connected: true } satisfies WsStateMessage);
-  };
+/**
+ * Ask the background script for the configured server URL and connectionId.
+ * The background script reads these from chrome.storage.local and relays here
+ * since offscreen docs cannot access chrome.storage APIs directly.
+ */
+const loadInitialConfigFromBackground = async (): Promise<{ url?: string; connectionId?: string }> => {
+  const response = await new Promise<{ url?: string; connectionId?: string } | undefined>(resolve => {
+    chrome.runtime.sendMessage(
+      { type: 'offscreen:getUrl' } satisfies InternalMessage,
+      (resp: { url?: string; connectionId?: string } | undefined) => {
+        if (chrome.runtime.lastError) {
+          resolve(undefined);
+          return;
+        }
+        resolve(resp);
+      },
+    );
+  });
+  return response ?? {};
+};
 
-  ws.onmessage = event => {
-    if (typeof event.data !== 'string') {
-      console.warn('[opentabs:offscreen] Received non-string WebSocket message, discarding');
-      return;
-    }
-    const text = event.data;
-    try {
-      const parsed: unknown = JSON.parse(text);
-
-      if (typeof parsed !== 'object' || parsed === null) return;
-      const msg = parsed as Record<string, unknown>;
-
-      // Handle pong — cancel the watchdog, connection is alive
-      if (msg.method === 'pong') {
-        onPongReceived();
-        return;
-      }
-
-      const method = msg.method as string | undefined;
-      const hasId = 'id' in msg;
-
-      // Allow response messages (have id, no method) — these are replies to
-      // requests the background script sent to the server (e.g., config.*).
-      // Allow request/notification messages only if their method is in the allowlist.
-      if (method && !ALLOWED_METHODS.has(method)) {
-        console.warn(`[opentabs:offscreen] Dropping message with unknown method: ${method}`);
-        return;
-      }
-
-      if (!method && !hasId) {
-        console.warn('[opentabs:offscreen] Dropping message with neither method nor id');
-        return;
-      }
-
-      sendToBackground({ type: 'ws:message', data: msg } satisfies WsDataMessage);
-    } catch {
-      console.warn('[opentabs:offscreen] Failed to parse WebSocket message as JSON');
-    }
-  };
-
-  ws.onclose = event => {
-    // The pong watchdog sets ws = null before calling ws.close(), so onclose
-    // fires with ws already null. Skip duplicate cleanup and notification.
-    if (!ws) {
-      reconnectScheduledByWatchdog = false;
-      return;
-    }
-
-    ws = null;
-    clearPingInterval();
-    clearPongWatchdog();
-
-    // Determine disconnect reason from the WebSocket close code.
-    // WS_CLOSE_AUTH_FAILED is sent by the MCP server when authentication fails
-    // during the WebSocket handshake (invalid or missing Sec-WebSocket-Protocol token).
-    if (event.code === WS_CLOSE_AUTH_FAILED) {
-      lastDisconnectReason = 'auth_failed';
-    } else if (!lastDisconnectReason) {
-      lastDisconnectReason = 'connection_refused';
-    }
-
+/** Chrome offscreen host: relays transport output to the background service worker. */
+const host: TransportHost = {
+  deliverMessage(msg: Record<string, unknown>): void {
+    sendToBackground({ type: 'ws:message', data: msg } satisfies WsDataMessage);
+  },
+  notifyState(state: WsConnectionState): void {
     sendToBackground({
       type: 'ws:state',
-      connected: false,
-      disconnectReason: lastDisconnectReason,
+      connected: state.connected,
+      disconnectReason: state.disconnectReason,
     } satisfies WsStateMessage);
-
-    // If the pong watchdog already scheduled a reconnect, skip to avoid double scheduling
-    if (reconnectScheduledByWatchdog) {
-      reconnectScheduledByWatchdog = false;
-      return;
-    }
-
-    scheduleReconnect();
-  };
-
-  ws.onerror = () => {
-    // onclose will fire after onerror — reconnect handled there
-  };
+  },
+  loadSecret: loadSecretFromAuthFile,
+  loadInitialConfig: loadInitialConfigFromBackground,
 };
+
+const transport = new WsTransport(host);
 
 // --- Message routing from background script ---
 
@@ -392,83 +118,18 @@ chrome.runtime.onMessage.addListener((message: InternalMessage, sender, sendResp
 
   switch (message.type) {
     case 'ws:send': {
-      if (ws?.readyState === WebSocket.OPEN) {
-        try {
-          ws.send(JSON.stringify(message.data));
-        } catch (err) {
-          const method =
-            typeof message.data === 'object' && message.data !== null
-              ? (message.data as Record<string, unknown>).method
-              : undefined;
-          console.error('[opentabs:offscreen] Failed to serialize message for WebSocket:', method, err);
-        }
-        sendResponse({ sent: true });
-      } else {
-        sendResponse({ sent: false, reason: 'not connected' });
-      }
+      sendResponse(transport.send(message.data));
       break;
     }
 
     case 'ws:getState': {
-      const isConnected = ws?.readyState === WebSocket.OPEN;
-      sendResponse({
-        connected: isConnected,
-        disconnectReason: isConnected ? undefined : lastDisconnectReason,
-      });
+      sendResponse(transport.getState());
       break;
     }
 
     case 'ws:setUrl': {
       void (async () => {
-        const rawUrl = message.url;
-
-        // Validate URL format and protocol before using it
-        try {
-          const parsed = new URL(rawUrl);
-          if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
-            console.warn(`[opentabs:offscreen] Rejected ws:setUrl with invalid protocol: ${parsed.protocol}`);
-            sendResponse({ ok: false, reason: 'Invalid WebSocket protocol' });
-            return;
-          }
-        } catch {
-          console.warn('[opentabs:offscreen] Rejected ws:setUrl: invalid URL format');
-          sendResponse({ ok: false, reason: 'Invalid URL format' });
-          return;
-        }
-
-        const httpBase = wsToHttpBase(rawUrl);
-        let resolvedUrl = rawUrl;
-        const result = await fetchWsInfo(httpBase);
-        if ('response' in result && result.response.ok) {
-          let wsInfo: { wsUrl?: string };
-          try {
-            wsInfo = (await result.response.json()) as { wsUrl?: string };
-          } catch {
-            console.warn('[opentabs:offscreen] Failed to parse /ws-info response as JSON');
-            sendResponse({ ok: false, reason: 'Invalid /ws-info response' });
-            return;
-          }
-          if (typeof wsInfo.wsUrl === 'string' && wsInfo.wsUrl !== '') {
-            if (isValidWsOrigin(wsInfo.wsUrl, httpBase)) {
-              resolvedUrl = wsInfo.wsUrl;
-            } else {
-              sendResponse({ ok: false, reason: 'WebSocket URL origin mismatch' });
-              return;
-            }
-          } else if (typeof wsInfo.wsUrl === 'string') {
-            console.warn('[opentabs:offscreen] /ws-info returned empty wsUrl, using fallback URL');
-          }
-        }
-        if (!isValidWsOrigin(resolvedUrl, httpBase)) {
-          sendResponse({ ok: false, reason: 'WebSocket URL origin mismatch' });
-          return;
-        }
-        if (resolvedUrl !== mcpServerUrl) {
-          console.log(`[opentabs:offscreen] MCP server URL changed to ${resolvedUrl}`);
-          mcpServerUrl = resolvedUrl;
-          disconnectAndReconnect('URL changed');
-        }
-        sendResponse({ ok: true });
+        sendResponse(await transport.setUrl(message.url));
       })();
       // Async sendResponse — tell Chrome to keep the message channel open
       return true;
@@ -483,18 +144,13 @@ chrome.runtime.onMessage.addListener((message: InternalMessage, sender, sendResp
     }
 
     case 'bg:forceReconnect': {
-      disconnectAndReconnect('Force reconnect');
+      transport.forceReconnect();
       sendResponse({ ok: true });
       break;
     }
 
     case 'port-changed': {
-      const newUrl = buildWsUrl(message.port);
-      if (newUrl !== mcpServerUrl) {
-        console.log(`[opentabs:offscreen] Port changed to ${message.port}, reconnecting`);
-        mcpServerUrl = newUrl;
-        disconnectAndReconnect('Port changed');
-      }
+      transport.portChanged(message.port);
       sendResponse({ ok: true });
       break;
     }
@@ -524,71 +180,4 @@ chrome.runtime.onMessage.addListener((message: InternalMessage, sender, sendResp
   return undefined;
 });
 
-/**
- * Bootstrap the shared secret from auth.json.
- *
- * The MCP server writes auth.json to the managed extension directory
- * (~/.opentabs/extension/auth.json) on startup. The offscreen document
- * reads it via chrome.runtime.getURL to obtain the secret, avoiding an
- * unauthenticated HTTP request to /ws-info. Port configuration is read
- * from chrome.storage.local (via the background script) separately.
- */
-const bootstrapFromAuthFile = async (): Promise<void> => {
-  try {
-    const authUrl = `${chrome.runtime.getURL('auth.json')}?_t=${Date.now()}`;
-    const res = await fetch(authUrl, { signal: AbortSignal.timeout(1_000), cache: 'no-store' });
-    if (res.ok) {
-      const auth = (await res.json()) as { secret?: string };
-      if (typeof auth.secret === 'string' && auth.secret !== '') {
-        wsSecret = auth.secret;
-        authJsonWarned = false;
-      } else if (!authJsonWarned) {
-        authJsonWarned = true;
-        console.warn('[opentabs:offscreen] auth.json missing or invalid secret field');
-      }
-    } else if (!authJsonWarned) {
-      authJsonWarned = true;
-      console.warn('[opentabs:offscreen] auth.json returned HTTP', res.status);
-    }
-  } catch (e) {
-    if (!authJsonWarned) {
-      authJsonWarned = true;
-      console.warn('[opentabs:offscreen] Failed to read auth.json:', e);
-    }
-  }
-};
-
-// Bootstrap the secret from auth.json, then get the port-based URL from
-// the background script (chrome.storage.local), and connect.
-void (async () => {
-  await bootstrapFromAuthFile();
-
-  // Read config from the background script: custom server URL and connectionId.
-  // The background script reads these from chrome.storage.local and relays here
-  // since offscreen docs cannot access chrome.storage APIs directly.
-  try {
-    const response = await new Promise<{ url?: string; connectionId?: string } | undefined>(resolve => {
-      chrome.runtime.sendMessage(
-        { type: 'offscreen:getUrl' } satisfies InternalMessage,
-        (resp: { url?: string; connectionId?: string } | undefined) => {
-          if (chrome.runtime.lastError) {
-            resolve(undefined);
-            return;
-          }
-          resolve(resp);
-        },
-      );
-    });
-    if (response?.url && typeof response.url === 'string' && response.url !== mcpServerUrl) {
-      mcpServerUrl = response.url;
-    }
-    if (response?.connectionId && typeof response.connectionId === 'string') {
-      connectionId = response.connectionId;
-    }
-  } catch {
-    // Background not ready — use URL from auth.json or default
-  }
-
-  console.log(`[opentabs:offscreen] Connecting to ${mcpServerUrl}`);
-  void connect();
-})();
+void transport.start();

--- a/platform/browser-extension/src/side-panel-toggle.ts
+++ b/platform/browser-extension/src/side-panel-toggle.ts
@@ -5,6 +5,29 @@
 
 import { SIDE_PANEL_OPEN_WINDOWS_KEY } from './constants.js';
 
+declare const __OPENTABS_IS_FIREFOX__: boolean | undefined;
+
+type ChromeSidePanelApi = {
+  setPanelBehavior?(options: { openPanelOnActionClick: boolean }): Promise<void>;
+  open?(options: { windowId: number }): Promise<void>;
+  close?(options: { windowId: number }): Promise<void>;
+  onOpened?: { addListener(listener: (details: { windowId: number }) => void): void };
+  onClosed?: { addListener(listener: (details: { windowId: number }) => void): void };
+};
+
+type FirefoxSidebarActionApi = {
+  open?(): Promise<void> | void;
+  toggle?(): Promise<void> | void;
+};
+
+const CHROME_SIDE_PANEL_KEY = 'side' + 'Panel';
+
+const getChromeSidePanel = (): ChromeSidePanelApi | undefined =>
+  (chrome as unknown as Record<string, ChromeSidePanelApi | undefined>)[CHROME_SIDE_PANEL_KEY];
+
+const getFirefoxSidebarAction = (): FirefoxSidebarActionApi | undefined =>
+  (chrome as unknown as { sidebarAction?: FirefoxSidebarActionApi }).sidebarAction;
+
 const openWindows = new Set<number>();
 
 /** Persist openWindows to chrome.storage.session (best-effort) */
@@ -41,27 +64,74 @@ const restoreOpenWindows = (): void => {
  */
 export const isSidePanelOpen = (): boolean => openWindows.size > 0;
 
-/** Initialize side panel toggle behavior and register Chrome event listeners */
+/**
+ * Open the extension panel using Chrome's sidePanel API when present, or
+ * Firefox's sidebarAction API when building/running as a Firefox WebExtension.
+ * Returns false when neither API is available.
+ */
+export const openExtensionPanel = async (windowId?: number): Promise<boolean> => {
+  if (!(typeof __OPENTABS_IS_FIREFOX__ === 'boolean' && __OPENTABS_IS_FIREFOX__)) {
+    const sidePanel = getChromeSidePanel();
+    if (sidePanel?.open && windowId !== undefined) {
+      await sidePanel.open({ windowId });
+      return true;
+    }
+  }
+
+  const sidebarAction = getFirefoxSidebarAction();
+  if (sidebarAction?.open) {
+    await sidebarAction.open();
+    return true;
+  }
+  if (sidebarAction?.toggle) {
+    await sidebarAction.toggle();
+    return true;
+  }
+
+  return false;
+};
+
+/** Initialize side panel/sidebar toggle behavior and register browser event listeners */
 export const initSidePanelToggle = (): void => {
+  // Firefox has sidebarAction instead of Chrome sidePanel. Keep action-click
+  // useful without touching Chrome-only APIs that are undefined in Firefox.
+  if (typeof __OPENTABS_IS_FIREFOX__ === 'boolean' && __OPENTABS_IS_FIREFOX__) {
+    chrome.action.onClicked.addListener(({ windowId }) => {
+      void openExtensionPanel(windowId);
+    });
+    return;
+  }
+
+  const sidePanel = getChromeSidePanel();
+
+  // Older Chrome / unexpected browsers: keep action-click useful without
+  // assuming the sidePanel API exists.
+  if (!sidePanel?.open || !sidePanel.setPanelBehavior) {
+    chrome.action.onClicked.addListener(({ windowId }) => {
+      void openExtensionPanel(windowId);
+    });
+    return;
+  }
+
   // Take manual control of the side panel so we can open/close it on action click.
-  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
+  sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
 
   // Chrome 141+ — track open/close state per window for toggle behavior.
   // On older Chrome (114–140), these APIs are undefined; openWindows stays
   // empty and the action click always opens the side panel.
-  const canToggle = 'onOpened' in chrome.sidePanel;
+  const canToggle = sidePanel.onOpened !== undefined && sidePanel.onClosed !== undefined && sidePanel.close !== undefined;
 
   if (canToggle) {
     // Restore persisted open-window state so the toggle works correctly after
     // the MV3 service worker suspends and wakes (module state is wiped on wake).
     restoreOpenWindows();
 
-    chrome.sidePanel.onOpened.addListener(({ windowId }) => {
+    sidePanel.onOpened?.addListener(({ windowId }) => {
       openWindows.add(windowId);
       persistOpenWindows();
     });
 
-    chrome.sidePanel.onClosed.addListener(({ windowId }) => {
+    sidePanel.onClosed?.addListener(({ windowId }) => {
       openWindows.delete(windowId);
       persistOpenWindows();
     });
@@ -82,12 +152,12 @@ export const initSidePanelToggle = (): void => {
         } catch {
           openWindows.delete(windowId);
           persistOpenWindows();
-          await chrome.sidePanel.open({ windowId }).catch(() => {});
+          await openExtensionPanel(windowId).catch(() => {});
           return;
         }
-        chrome.sidePanel.close({ windowId }).catch(() => {});
+        sidePanel.close?.({ windowId }).catch(() => {});
       } else {
-        chrome.sidePanel.open({ windowId }).catch(() => {});
+        await openExtensionPanel(windowId).catch(() => {});
       }
     })();
   });

--- a/platform/browser-extension/src/transport/firefox-background-transport.ts
+++ b/platform/browser-extension/src/transport/firefox-background-transport.ts
@@ -1,0 +1,107 @@
+/**
+ * Firefox host for the persistent WebSocket transport.
+ *
+ * Firefox has no `chrome.offscreen` API, but a Firefox MV3 background event page
+ * *can* hold a long-lived WebSocket. So on Firefox the same {@link WsTransport}
+ * that Chrome runs inside an offscreen document runs directly in the background
+ * page. This module provides the Firefox-flavoured {@link TransportHost} and a
+ * single entry point, {@link startFirefoxBackgroundTransport}, that the
+ * background script calls in place of `ensureOffscreenDocument()`.
+ *
+ * Because the transport runs in the same context as the consumer, inbound
+ * messages and state are delivered through direct in-process callbacks
+ * ({@link TransportConsumer}) rather than round-tripping through
+ * `chrome.runtime.sendMessage` (which does not reliably deliver a context's own
+ * messages back to itself).
+ *
+ * Wiring into `background.ts` (selecting this path when {@link isFirefox}) lands
+ * with the Firefox build target; this module is the isolated, Chrome-safe
+ * Firefox transport surface it depends on.
+ */
+
+import { buildWsUrl, SERVER_PORT_KEY } from '../constants.js';
+import { isFirefox } from './target.js';
+import type { TransportHost, WsConnectionState } from './ws-transport.js';
+import { WsTransport } from './ws-transport.js';
+
+/**
+ * Consumer of transport output, implemented by the background script. These
+ * are the same two effects the Chrome offscreen host relays via `ws:message`
+ * and `ws:state`, delivered here as direct calls.
+ */
+export interface TransportConsumer {
+  /** Handle a validated inbound JSON-RPC message from the MCP server. */
+  onMessage(msg: Record<string, unknown>): void;
+  /** Handle a connection-state transition. */
+  onState(state: WsConnectionState): void;
+}
+
+/** Read the shared secret from auth.json (available to the background page). */
+const loadSecretFromAuthFile = async (): Promise<string | null> => {
+  try {
+    const authUrl = `${chrome.runtime.getURL('auth.json')}?_t=${Date.now()}`;
+    const res = await fetch(authUrl, { signal: AbortSignal.timeout(1_000), cache: 'no-store' });
+    if (res.ok) {
+      const auth = (await res.json()) as { secret?: string };
+      if (typeof auth.secret === 'string' && auth.secret !== '') {
+        return auth.secret;
+      }
+    }
+  } catch {
+    // auth.json not yet written — connect unauthenticated and retry on 401
+  }
+  return null;
+};
+
+/**
+ * Read the configured server URL and connectionId directly from
+ * chrome.storage.local. The background page has storage access, so unlike the
+ * Chrome offscreen host there is no need to relay through a message.
+ */
+const loadInitialConfig = async (): Promise<{ url?: string; connectionId?: string }> => {
+  const stored: Record<string, unknown> = await chrome.storage.local
+    .get([SERVER_PORT_KEY, 'connectionId'])
+    .catch(() => ({}) as Record<string, unknown>);
+  const port =
+    typeof stored[SERVER_PORT_KEY] === 'number' && (stored[SERVER_PORT_KEY] as number) > 0
+      ? (stored[SERVER_PORT_KEY] as number)
+      : undefined;
+  const url = port ? buildWsUrl(port) : undefined;
+  const connectionId = typeof stored.connectionId === 'string' ? stored.connectionId : undefined;
+  return { url, connectionId };
+};
+
+/**
+ * Start the persistent WebSocket transport in the Firefox background page.
+ *
+ * Returns the live {@link WsTransport} so the background script can drive it
+ * (send, setUrl, portChanged, forceReconnect) from its own message handlers and
+ * storage listeners — the same surface the Chrome path drives via messages to
+ * the offscreen document.
+ *
+ * Throws on a non-Firefox build: running this on Chrome would open a second
+ * connection alongside the offscreen document's. The Chrome path must use
+ * `ensureOffscreenDocument()` instead.
+ */
+export const startFirefoxBackgroundTransport = (consumer: TransportConsumer): WsTransport => {
+  if (!isFirefox) {
+    throw new Error(
+      'startFirefoxBackgroundTransport called on a non-Firefox build. Chrome must run the WebSocket in an offscreen document.',
+    );
+  }
+
+  const host: TransportHost = {
+    deliverMessage(msg: Record<string, unknown>): void {
+      consumer.onMessage(msg);
+    },
+    notifyState(state: WsConnectionState): void {
+      consumer.onState(state);
+    },
+    loadSecret: loadSecretFromAuthFile,
+    loadInitialConfig,
+  };
+
+  const transport = new WsTransport(host);
+  void transport.start();
+  return transport;
+};

--- a/platform/browser-extension/src/transport/firefox-background-transport.ts
+++ b/platform/browser-extension/src/transport/firefox-background-transport.ts
@@ -67,7 +67,20 @@ const loadInitialConfig = async (): Promise<{ url?: string; connectionId?: strin
       ? (stored[SERVER_PORT_KEY] as number)
       : undefined;
   const url = port ? buildWsUrl(port) : undefined;
-  const connectionId = typeof stored.connectionId === 'string' ? stored.connectionId : undefined;
+  let connectionId = typeof stored.connectionId === 'string' ? stored.connectionId : undefined;
+
+  // Firefox starts the transport directly from the background page. That can
+  // happen before background.ts' top-level ensureConnectionId() has finished,
+  // so make the transport host self-sufficient and guarantee the first WebSocket
+  // connection carries a stable installation identity.
+  if (!connectionId) {
+    connectionId = crypto.randomUUID();
+    await chrome.storage.local.set({ connectionId }).catch(() => {
+      // Storage may be temporarily unavailable during startup; still use the
+      // generated ID for this session and let background.ts retry persistence.
+    });
+  }
+
   return { url, connectionId };
 };
 

--- a/platform/browser-extension/src/transport/target.ts
+++ b/platform/browser-extension/src/transport/target.ts
@@ -1,21 +1,23 @@
 /**
  * Build-time target platform.
  *
- * `__OPENTABS_TARGET__` is substituted by esbuild via a `define` (see
- * `build-extension.ts`). The Chrome build leaves it as the default `'chrome'`;
- * a Firefox build sets `OPENTABS_TARGET=firefox`, which makes esbuild inline the
- * literal `'firefox'` and dead-code-eliminate the unused branch.
+ * `__OPENTABS_TARGET__` and `__OPENTABS_IS_FIREFOX__` are substituted by
+ * esbuild via `define` (see `build-extension.ts`). The Chrome build leaves the
+ * target as the default `'chrome'`; a Firefox build sets `OPENTABS_TARGET=firefox`,
+ * which makes esbuild inline literals and dead-code-eliminate unused branches.
  *
- * Using a `define`d global (rather than reading an env var at runtime) keeps the
- * bundle self-contained and lets the bundler strip the unused transport path
- * entirely from each target's output.
+ * Cross-module consumers use the exported `isFirefox` runtime flag. Bundles that
+ * must remove static references to browser-specific APIs should guard those
+ * references directly with `__OPENTABS_IS_FIREFOX__` in the same module so
+ * esbuild can drop the dead branch before AMO/Firefox linting.
  */
 
 declare const __OPENTABS_TARGET__: 'chrome' | 'firefox' | undefined;
+declare const __OPENTABS_IS_FIREFOX__: boolean | undefined;
 
 export type ExtensionTarget = 'chrome' | 'firefox';
 
 /** The platform this bundle was built for. Defaults to 'chrome'. */
 export const TARGET: ExtensionTarget = typeof __OPENTABS_TARGET__ === 'string' ? __OPENTABS_TARGET__ : 'chrome';
 
-export const isFirefox = TARGET === 'firefox';
+export const isFirefox = typeof __OPENTABS_IS_FIREFOX__ === 'boolean' ? __OPENTABS_IS_FIREFOX__ : TARGET === 'firefox';

--- a/platform/browser-extension/src/transport/target.ts
+++ b/platform/browser-extension/src/transport/target.ts
@@ -1,0 +1,21 @@
+/**
+ * Build-time target platform.
+ *
+ * `__OPENTABS_TARGET__` is substituted by esbuild via a `define` (see
+ * `build-extension.ts`). The Chrome build leaves it as the default `'chrome'`;
+ * a Firefox build sets `OPENTABS_TARGET=firefox`, which makes esbuild inline the
+ * literal `'firefox'` and dead-code-eliminate the unused branch.
+ *
+ * Using a `define`d global (rather than reading an env var at runtime) keeps the
+ * bundle self-contained and lets the bundler strip the unused transport path
+ * entirely from each target's output.
+ */
+
+declare const __OPENTABS_TARGET__: 'chrome' | 'firefox' | undefined;
+
+export type ExtensionTarget = 'chrome' | 'firefox';
+
+/** The platform this bundle was built for. Defaults to 'chrome'. */
+export const TARGET: ExtensionTarget = typeof __OPENTABS_TARGET__ === 'string' ? __OPENTABS_TARGET__ : 'chrome';
+
+export const isFirefox = TARGET === 'firefox';

--- a/platform/browser-extension/src/transport/ws-transport.ts
+++ b/platform/browser-extension/src/transport/ws-transport.ts
@@ -1,0 +1,537 @@
+/**
+ * Persistent WebSocket transport to the MCP server.
+ *
+ * This module owns the full connection lifecycle — connect, exponential-backoff
+ * reconnect, ping/pong keepalive, inbound-message validation, and outbound send.
+ * It is platform-neutral: it talks to its surrounding extension context only
+ * through the injected {@link TransportHost}.
+ *
+ * Two contexts host this transport:
+ *
+ * - **Chrome**: an offscreen document (`src/offscreen/index.ts`) runs the
+ *   transport because a Manifest V3 service worker cannot hold a long-lived
+ *   WebSocket. The host relays inbound messages and state to the background
+ *   service worker via `chrome.runtime.sendMessage`.
+ * - **Firefox**: the background event page runs the transport directly
+ *   (`src/transport/firefox-background-transport.ts`), since Firefox event
+ *   pages can hold a long-lived WebSocket and Firefox has no offscreen API.
+ *
+ * Reconnection: exponential backoff (1s → 2s → … → 3s cap), resets on success.
+ * Keepalive: sends ping every 15s; if no pong within 5s, the connection is
+ *            considered dead and force-closed to trigger reconnect. This detects
+ *            zombie connections caused by server hot reload where the TCP socket
+ *            stays alive but the server-side handler has been replaced.
+ *
+ * The WebSocket URL defaults to ws://127.0.0.1:9515/ws. The port is configurable
+ * by the host (read from chrome.storage.local in both contexts).
+ */
+
+import {
+  buildWsUrl,
+  DEFAULT_SERVER_PORT,
+  WS_CLOSE_AUTH_FAILED,
+  WS_CLOSE_PONG_TIMEOUT,
+  WS_INFO_TIMEOUT_MS,
+} from '../constants.js';
+import type { DisconnectReason } from '../extension-messages.js';
+import { ALL_ALLOWED_METHODS } from '../known-methods.js';
+import { isValidWsOrigin, wsToHttpBase } from '../offscreen/ws-utils.js';
+
+const DEFAULT_MCP_SERVER_URL = buildWsUrl(DEFAULT_SERVER_PORT);
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 3000;
+const BACKOFF_MULTIPLIER = 2;
+
+// Ping/pong keepalive — tuned for fast zombie detection during hot reload
+const PING_INTERVAL_MS = 15_000; // Send ping every 15s
+const PONG_TIMEOUT_MS = 5_000; // Expect pong within 5s or connection is dead
+
+/**
+ * Allowlist of expected JSON-RPC methods from the MCP server.
+ * Messages with methods not in this set (and without an `id` response field)
+ * are dropped to prevent forwarding unexpected payloads to the consumer.
+ *
+ * Derived from ALL_ALLOWED_METHODS in known-methods.ts — the single source of
+ * truth for all recognized WebSocket methods.
+ */
+const ALLOWED_METHODS = new Set<string>(ALL_ALLOWED_METHODS);
+
+/** Connection state surfaced to the host on every transition. */
+export interface WsConnectionState {
+  connected: boolean;
+  disconnectReason?: DisconnectReason;
+}
+
+/**
+ * Platform glue the transport needs from its surrounding extension context.
+ * The transport never touches `chrome.*` APIs directly — every side effect
+ * that differs between the Chrome offscreen document and the Firefox
+ * background page goes through this interface.
+ */
+export interface TransportHost {
+  /** Deliver a validated inbound JSON-RPC message to the consumer (background). */
+  deliverMessage(msg: Record<string, unknown>): void;
+  /** Notify the consumer of a connection-state transition. */
+  notifyState(state: WsConnectionState): void;
+  /**
+   * Read the current shared secret (from auth.json). Called before each
+   * connection attempt and on 401 retry so secret rotation is picked up
+   * automatically. Returns the secret, or null if unavailable.
+   */
+  loadSecret(): Promise<string | null>;
+  /**
+   * Load the initial server URL and connection ID. Called once at startup.
+   * Both are read from chrome.storage.local by the host.
+   */
+  loadInitialConfig(): Promise<{ url?: string; connectionId?: string }>;
+}
+
+/** Result of a {@link WsTransport.send} call. */
+export interface SendResult {
+  sent: boolean;
+  reason?: string;
+}
+
+/** Result of a {@link WsTransport.setUrl} call. */
+export interface SetUrlResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export class WsTransport {
+  private readonly host: TransportHost;
+
+  private mcpServerUrl = DEFAULT_MCP_SERVER_URL;
+  /** WebSocket auth token — sent via Sec-WebSocket-Protocol header, not URL query */
+  private wsSecret: string | null = null;
+  private ws: WebSocket | null = null;
+  private backoffMs = INITIAL_BACKOFF_MS;
+  private pingIntervalId: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private pongWatchdogId: ReturnType<typeof setTimeout> | null = null;
+  private awaitingPong = false;
+  /** Guard flag to prevent double reconnect when pong watchdog triggers ws.close() */
+  private reconnectScheduledByWatchdog = false;
+  /** Guard flag to prevent concurrent connect() calls during the async refreshWsUrl phase */
+  private connecting = false;
+  /** Tracks why the last connection attempt failed, for side panel error state display */
+  private lastDisconnectReason: DisconnectReason | undefined;
+  /** Stable connection ID per extension installation — sent in WebSocket subprotocol header */
+  private connectionId: string | null = null;
+
+  constructor(host: TransportHost) {
+    this.host = host;
+  }
+
+  /**
+   * Bootstrap the secret and initial config from the host, then connect.
+   * Call exactly once after construction.
+   */
+  async start(): Promise<void> {
+    this.wsSecret = await this.host.loadSecret();
+
+    try {
+      const config = await this.host.loadInitialConfig();
+      if (config.url && typeof config.url === 'string' && config.url !== this.mcpServerUrl) {
+        this.mcpServerUrl = config.url;
+      }
+      if (config.connectionId && typeof config.connectionId === 'string') {
+        this.connectionId = config.connectionId;
+      }
+    } catch {
+      // Config not ready — use URL from secret bootstrap or default
+    }
+
+    console.log(`[opentabs:transport] Connecting to ${this.mcpServerUrl}`);
+    void this.connect();
+  }
+
+  /** Send a JSON-RPC message to the server. Returns whether it was sent. */
+  send(data: unknown): SendResult {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(JSON.stringify(data));
+      } catch (err) {
+        const method =
+          typeof data === 'object' && data !== null ? (data as Record<string, unknown>).method : undefined;
+        console.error('[opentabs:transport] Failed to serialize message for WebSocket:', method, err);
+      }
+      return { sent: true };
+    }
+    return { sent: false, reason: 'not connected' };
+  }
+
+  /** Current connection state. */
+  getState(): WsConnectionState {
+    const isConnected = this.ws?.readyState === WebSocket.OPEN;
+    return {
+      connected: isConnected,
+      disconnectReason: isConnected ? undefined : this.lastDisconnectReason,
+    };
+  }
+
+  /**
+   * Validate and apply a new server URL, then reconnect. The raw URL is
+   * resolved against /ws-info and origin-checked before use.
+   */
+  async setUrl(rawUrl: string): Promise<SetUrlResult> {
+    // Validate URL format and protocol before using it
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+        console.warn(`[opentabs:transport] Rejected setUrl with invalid protocol: ${parsed.protocol}`);
+        return { ok: false, reason: 'Invalid WebSocket protocol' };
+      }
+    } catch {
+      console.warn('[opentabs:transport] Rejected setUrl: invalid URL format');
+      return { ok: false, reason: 'Invalid URL format' };
+    }
+
+    const httpBase = wsToHttpBase(rawUrl);
+    let resolvedUrl = rawUrl;
+    const result = await this.fetchWsInfo(httpBase);
+    if ('response' in result && result.response.ok) {
+      let wsInfo: { wsUrl?: string };
+      try {
+        wsInfo = (await result.response.json()) as { wsUrl?: string };
+      } catch {
+        console.warn('[opentabs:transport] Failed to parse /ws-info response as JSON');
+        return { ok: false, reason: 'Invalid /ws-info response' };
+      }
+      if (typeof wsInfo.wsUrl === 'string' && wsInfo.wsUrl !== '') {
+        if (isValidWsOrigin(wsInfo.wsUrl, httpBase)) {
+          resolvedUrl = wsInfo.wsUrl;
+        } else {
+          return { ok: false, reason: 'WebSocket URL origin mismatch' };
+        }
+      } else if (typeof wsInfo.wsUrl === 'string') {
+        console.warn('[opentabs:transport] /ws-info returned empty wsUrl, using fallback URL');
+      }
+    }
+    if (!isValidWsOrigin(resolvedUrl, httpBase)) {
+      return { ok: false, reason: 'WebSocket URL origin mismatch' };
+    }
+    if (resolvedUrl !== this.mcpServerUrl) {
+      console.log(`[opentabs:transport] MCP server URL changed to ${resolvedUrl}`);
+      this.mcpServerUrl = resolvedUrl;
+      this.disconnectAndReconnect('URL changed');
+    }
+    return { ok: true };
+  }
+
+  /** Force a fresh reconnect (e.g., bg:forceReconnect). */
+  forceReconnect(): void {
+    this.disconnectAndReconnect('Force reconnect');
+  }
+
+  /** Apply a new port (builds the ws URL) and reconnect if it changed. */
+  portChanged(port: number): void {
+    const newUrl = buildWsUrl(port);
+    if (newUrl !== this.mcpServerUrl) {
+      console.log(`[opentabs:transport] Port changed to ${port}, reconnecting`);
+      this.mcpServerUrl = newUrl;
+      this.disconnectAndReconnect('Port changed');
+    }
+  }
+
+  // --- /ws-info fetch ---
+
+  /**
+   * Fetch /ws-info from the MCP server with automatic 401 retry.
+   *
+   * On 401, re-reads the secret for the latest value and retries once.
+   * Returns `{ response }` on success (caller inspects .ok / .status),
+   * `{ reason: 'auth_failed' }` on double-401, or
+   * `{ reason: 'connection_refused' }` on network error.
+   */
+  private async fetchWsInfo(httpBase: string): Promise<{ response: Response } | { reason: DisconnectReason }> {
+    try {
+      const headers: Record<string, string> = {};
+      if (this.wsSecret) headers.Authorization = `Bearer ${this.wsSecret}`;
+      let res = await fetch(`${httpBase}/ws-info`, {
+        headers,
+        signal: AbortSignal.timeout(WS_INFO_TIMEOUT_MS),
+        cache: 'no-store',
+      });
+      // 401 means the secret is stale (e.g., server rotated secrets during hot
+      // reload). Re-read the secret for the latest value and retry once.
+      if (res.status === 401) {
+        this.wsSecret = await this.host.loadSecret();
+        const retryHeaders: Record<string, string> = {};
+        if (this.wsSecret) retryHeaders.Authorization = `Bearer ${this.wsSecret}`;
+        res = await fetch(`${httpBase}/ws-info`, {
+          headers: retryHeaders,
+          signal: AbortSignal.timeout(WS_INFO_TIMEOUT_MS),
+          cache: 'no-store',
+        });
+      }
+      if (res.status === 401) return { reason: 'auth_failed' };
+      return { response: res };
+    } catch {
+      return { reason: 'connection_refused' };
+    }
+  }
+
+  /**
+   * Close any active WebSocket connection, cancel any pending reconnect timer,
+   * reset backoff, and initiate a fresh connection.
+   */
+  private disconnectAndReconnect(closeReason: string): void {
+    this.backoffMs = INITIAL_BACKOFF_MS;
+    this.lastDisconnectReason = undefined;
+    if (this.ws) {
+      try {
+        this.ws.close(1000, closeReason);
+      } catch {
+        // Already closed
+      }
+    } else if (this.reconnectTimeoutId !== null) {
+      // No active connection and backoff timer is pending — cancel it
+      // and connect immediately with the new URL.
+      clearTimeout(this.reconnectTimeoutId);
+      this.reconnectTimeoutId = null;
+      void this.connect();
+    } else {
+      // No active connection and no pending reconnect (backoff exhausted
+      // or no connection was ever established) — connect immediately.
+      void this.connect();
+    }
+  }
+
+  // --- Ping/Pong watchdog ---
+
+  private clearPingInterval(): void {
+    if (this.pingIntervalId !== null) {
+      clearInterval(this.pingIntervalId);
+      this.pingIntervalId = null;
+    }
+  }
+
+  private clearPongWatchdog(): void {
+    if (this.pongWatchdogId !== null) {
+      clearTimeout(this.pongWatchdogId);
+      this.pongWatchdogId = null;
+    }
+    this.awaitingPong = false;
+  }
+
+  /** Called when a pong is received — connection is healthy. */
+  private onPongReceived(): void {
+    this.clearPongWatchdog();
+  }
+
+  /**
+   * Send a ping and arm the watchdog.
+   * If the watchdog fires before a pong arrives, the connection is dead.
+   */
+  private sendPing = (): void => {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+
+    // Don't stack pings — if we're still waiting for a pong from the last
+    // ping, the watchdog is already running and will handle it.
+    if (this.awaitingPong) return;
+
+    this.ws.send(JSON.stringify({ jsonrpc: '2.0', method: 'ping' }));
+    this.awaitingPong = true;
+
+    // Arm the watchdog: if no pong within PONG_TIMEOUT_MS, kill the connection
+    this.pongWatchdogId = setTimeout(() => {
+      this.pongWatchdogId = null;
+
+      if (!this.awaitingPong) return; // Pong arrived just in time
+
+      console.warn(
+        '[opentabs:transport] Pong timeout — connection is dead (likely server hot reload). Forcing reconnect.',
+      );
+      this.awaitingPong = false;
+
+      // Force-close the zombie WebSocket. This triggers onclose → reconnect.
+      // Set the guard flag so onclose doesn't schedule a second reconnect.
+      if (this.ws) {
+        this.reconnectScheduledByWatchdog = true;
+        try {
+          this.ws.close(WS_CLOSE_PONG_TIMEOUT, 'Pong timeout');
+        } catch {
+          // Already closed
+        }
+        this.ws = null;
+        this.clearPingInterval();
+        this.lastDisconnectReason = 'timeout';
+        this.host.notifyState({ connected: false, disconnectReason: 'timeout' });
+        this.scheduleReconnect();
+      }
+    }, PONG_TIMEOUT_MS);
+  };
+
+  private startPingInterval(): void {
+    this.clearPingInterval();
+    this.clearPongWatchdog();
+
+    // Send pings on the regular interval (the first ping fires after one
+    // interval, giving the server time to send sync.full).
+    this.pingIntervalId = setInterval(this.sendPing, PING_INTERVAL_MS);
+  }
+
+  // --- Reconnect logic ---
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimeoutId !== null) {
+      clearTimeout(this.reconnectTimeoutId);
+    }
+    const delay = this.backoffMs;
+    this.reconnectTimeoutId = setTimeout(() => {
+      this.reconnectTimeoutId = null;
+      void this.connect();
+    }, delay);
+    this.backoffMs = Math.min(this.backoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
+  }
+
+  // --- Token refresh ---
+
+  /**
+   * Re-fetch the WebSocket URL and auth secret from /ws-info.
+   * Called before each connection attempt so reconnects after secret rotation
+   * pick up the new token automatically. Falls back to the current URL on error.
+   *
+   * Returns the disconnect reason if the server explicitly rejected us
+   * (auth_failed) or could not be reached (connection_refused). Returns
+   * undefined on success.
+   */
+  private async refreshWsUrl(): Promise<DisconnectReason | undefined> {
+    const httpBase = wsToHttpBase(this.mcpServerUrl);
+    const result = await this.fetchWsInfo(httpBase);
+    if ('reason' in result) return result.reason;
+
+    const res = result.response;
+    if (!res.ok) return 'connection_refused';
+
+    const wsInfo = (await res.json()) as { wsUrl?: string };
+    if (typeof wsInfo.wsUrl === 'string' && wsInfo.wsUrl !== '' && wsInfo.wsUrl !== this.mcpServerUrl) {
+      if (isValidWsOrigin(wsInfo.wsUrl, httpBase)) {
+        this.mcpServerUrl = wsInfo.wsUrl;
+      }
+    }
+    return undefined;
+  }
+
+  // --- Connection ---
+
+  private connect = async (): Promise<void> => {
+    if (
+      this.connecting ||
+      this.ws?.readyState === WebSocket.OPEN ||
+      this.ws?.readyState === WebSocket.CONNECTING
+    ) {
+      return;
+    }
+
+    this.connecting = true;
+    try {
+      this.wsSecret = await this.host.loadSecret();
+      const reason = await this.refreshWsUrl();
+      if (reason) {
+        this.lastDisconnectReason = reason;
+        this.host.notifyState({ connected: false, disconnectReason: reason });
+        this.scheduleReconnect();
+        return;
+      }
+      // Send auth token and connection ID via Sec-WebSocket-Protocol header (not URL query)
+      // to keep them out of server logs, browser history, and proxy logs.
+      // Format: ['opentabs', '<secret>', '<connectionId>']
+      const protocols: string[] = ['opentabs'];
+      if (this.wsSecret) protocols.push(this.wsSecret);
+      if (this.connectionId) protocols.push(this.connectionId);
+      this.ws = protocols.length > 1 ? new WebSocket(this.mcpServerUrl, protocols) : new WebSocket(this.mcpServerUrl);
+    } catch {
+      this.lastDisconnectReason = 'connection_refused';
+      this.host.notifyState({ connected: false, disconnectReason: 'connection_refused' });
+      this.scheduleReconnect();
+      return;
+    } finally {
+      this.connecting = false;
+    }
+
+    this.ws.onopen = () => {
+      this.backoffMs = INITIAL_BACKOFF_MS; // Reset backoff on success
+      this.lastDisconnectReason = undefined;
+      this.startPingInterval();
+      this.host.notifyState({ connected: true });
+    };
+
+    this.ws.onmessage = event => {
+      if (typeof event.data !== 'string') {
+        console.warn('[opentabs:transport] Received non-string WebSocket message, discarding');
+        return;
+      }
+      const text = event.data;
+      try {
+        const parsed: unknown = JSON.parse(text);
+
+        if (typeof parsed !== 'object' || parsed === null) return;
+        const msg = parsed as Record<string, unknown>;
+
+        // Handle pong — cancel the watchdog, connection is alive
+        if (msg.method === 'pong') {
+          this.onPongReceived();
+          return;
+        }
+
+        const method = msg.method as string | undefined;
+        const hasId = 'id' in msg;
+
+        // Allow response messages (have id, no method) — these are replies to
+        // requests the background script sent to the server (e.g., config.*).
+        // Allow request/notification messages only if their method is in the allowlist.
+        if (method && !ALLOWED_METHODS.has(method)) {
+          console.warn(`[opentabs:transport] Dropping message with unknown method: ${method}`);
+          return;
+        }
+
+        if (!method && !hasId) {
+          console.warn('[opentabs:transport] Dropping message with neither method nor id');
+          return;
+        }
+
+        this.host.deliverMessage(msg);
+      } catch {
+        console.warn('[opentabs:transport] Failed to parse WebSocket message as JSON');
+      }
+    };
+
+    this.ws.onclose = event => {
+      // The pong watchdog sets ws = null before calling ws.close(), so onclose
+      // fires with ws already null. Skip duplicate cleanup and notification.
+      if (!this.ws) {
+        this.reconnectScheduledByWatchdog = false;
+        return;
+      }
+
+      this.ws = null;
+      this.clearPingInterval();
+      this.clearPongWatchdog();
+
+      // Determine disconnect reason from the WebSocket close code.
+      // WS_CLOSE_AUTH_FAILED is sent by the MCP server when authentication fails
+      // during the WebSocket handshake (invalid or missing Sec-WebSocket-Protocol token).
+      if (event.code === WS_CLOSE_AUTH_FAILED) {
+        this.lastDisconnectReason = 'auth_failed';
+      } else if (!this.lastDisconnectReason) {
+        this.lastDisconnectReason = 'connection_refused';
+      }
+
+      this.host.notifyState({ connected: false, disconnectReason: this.lastDisconnectReason });
+
+      // If the pong watchdog already scheduled a reconnect, skip to avoid double scheduling
+      if (this.reconnectScheduledByWatchdog) {
+        this.reconnectScheduledByWatchdog = false;
+        return;
+      }
+
+      this.scheduleReconnect();
+    };
+
+    this.ws.onerror = () => {
+      // onclose will fire after onerror — reconnect handled there
+    };
+  };
+}


### PR DESCRIPTION
## Summary

This is a Firefox/WebExtensions port slice for the browser extension.

It keeps the default Chrome path intact while adding a Firefox build path that:

- translates the manifest via `manifest.firefox.json` (`background.service_worker` → `background.scripts`, `side_panel` → `sidebar_action`, Chrome-only permissions dropped)
- runs the existing WebSocket transport directly in the Firefox background page instead of a Chrome MV3 offscreen document
- routes outbound server traffic through the live Firefox background transport while preserving Chrome offscreen message relay
- adds a `sidebarAction` fallback for panel opening
- guards Chrome-only startup APIs so the Firefox background bundle no longer contains exact `chrome.offscreen` / `chrome.sidePanel` references

## Verification

Run locally in the worktree:

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` — 114 files, 3836 passed, 1 skipped
- [x] Chrome `build:bundle`
- [x] Firefox `OPENTABS_TARGET=firefox npm run --prefix platform/browser-extension build:bundle`
- [x] Firefox bundle forbidden-reference scan: no `chrome.offscreen`, no `chrome.sidePanel` in `platform/browser-extension/dist/background.js`
- [x] `npm run --prefix platform/browser-extension build:side-panel`
- [x] `npx tsx scripts/generate-icons.ts`
- [x] `npx tsx scripts/compute-extension-hash.ts`
- [x] `npm run --prefix platform/browser-extension build:firefox-manifest`
- [x] manifest assertions for Firefox transforms
- [x] `git diff --check`
- [x] fresh minimal Firefox staging + `addons-linter --self-hosted --output json`: 0 errors / 0 notices / 72 warnings

## Known limitations / follow-up

This is not yet full Firefox feature parity:

- `addons-linter` still warns about unsupported Firefox `chrome.debugger.*` usage in debugger-backed browser tools. The Firefox manifest drops the `debugger` permission, so these APIs need a later capability-gating/degradation pass.
- `addons-linter` also warns about bundled side-panel `innerHTML` assignments.
- I have not run a live Firefox browser session smoke test from this PR branch yet; current verification is static/build/package-level.

## Notes

The exact-reference scan is intentionally included because TypeScript/lint/tests can pass while the built Firefox background bundle still contains Chrome-only startup references.
