### PR TITLE
feat(teams): add teams.cloud.microsoft support

### DIFF
--- a/plugins/teams/package.json
+++ b/plugins/teams/package.json
@@ -21,7 +21,8 @@
     "description": "OpenTabs plugin for Microsoft Teams",
     "urlPatterns": [
       "*://teams.live.com/*",
-      "*://teams.microsoft.com/*"
+      "*://teams.microsoft.com/*",
+      "*://teams.cloud.microsoft/*"
     ],
     "homepage": "https://teams.live.com/v2/",
     "preScript": "src/pre-script.ts",

--- a/plugins/teams/src/teams-api.ts
+++ b/plugins/teams/src/teams-api.ts
@@ -35,7 +35,16 @@ const CONSUMER_CONFIG: EnvConfig = {
 };
 
 const ENTERPRISE_CONFIG: EnvConfig = {
-  authzUrl: 'https://teams.microsoft.com/api/authsvc/v1.0/authz',
+  get authzUrl() {
+    try {
+      if (typeof window !== 'undefined') {
+        return `${window.location.origin}/api/authsvc/v1.0/authz`;
+      }
+    } catch {
+      // fall through to default
+    }
+    return 'https://teams.microsoft.com/api/authsvc/v1.0/authz';
+  },
   chatServiceBase: null, // Discovered at runtime from regionGtms
 };
 
@@ -111,15 +120,15 @@ const discoverEnterpriseChatServiceBase = (): string => {
       const data = JSON.parse(entry.value) as {
         item?: { regionGtms?: { chatService?: string; chatServiceAfd?: string } };
       };
-      const chatService = data.item?.regionGtms?.chatService;
-      if (chatService) {
-        cachedEnterpriseChatServiceBase = chatService;
-        return chatService;
-      }
       const chatServiceAfd = data.item?.regionGtms?.chatServiceAfd;
       if (chatServiceAfd) {
         cachedEnterpriseChatServiceBase = chatServiceAfd;
         return chatServiceAfd;
+      }
+      const chatService = data.item?.regionGtms?.chatService;
+      if (chatService) {
+        cachedEnterpriseChatServiceBase = chatService;
+        return chatService;
       }
     } catch {
       // Fall through to default


### PR DESCRIPTION
- Add *://teams.cloud.microsoft/* to urlPatterns so the extension activates on the newer enterprise Teams domain.

- Derive authzUrl from window.location.origin instead of a hardcoded teams.microsoft.com value. Without this, the POST to /api/authsvc from teams.cloud.microsoft is a cross-origin request and fails with a CORS error, breaking the Skype JWT exchange for every API call.

- Prefer chatServiceAfd (geo-aware Azure Front Door endpoint) over chatService when discovering the enterprise chat service URL from regionGtms. On teams.cloud.microsoft, chatServiceAfd is always present and routes correctly for non-US regions; chatService may be absent or point to a US-only endpoint.

Verified end-to-end on teams.cloud.microsoft: teams_get_current_user, teams_list_conversations, teams_read_messages, and teams_get_conversation_details all return correct results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended support for additional Microsoft Teams cloud domains to improve platform compatibility
  * Enhanced authentication service URL configuration with dynamic resolution and improved fallback handling
  * Optimized enterprise chat service discovery and routing prioritization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->