### PR TITLE
fix(office): capture refreshed Graph token via XHR on SharePoint

### DIFF
--- a/plugins/microsoft-word/src/pre-script.ts
+++ b/plugins/microsoft-word/src/pre-script.ts
@@ -9,15 +9,15 @@ import { definePreScript } from '@opentabs-dev/plugin-sdk/pre-script';
  * edits through the cross-origin WOPI canvas and MSAL stores its token cache
  * encrypted, so there is no plaintext Graph token to read from `localStorage`.
  * What the page does on load is mint per-resource access tokens by POSTing to
- * the AAD token endpoint (`login.microsoftonline.com/<tenant>/oauth2/v2.0/token`)
- * via `fetch`; each response is plaintext JSON with `access_token`, `scope`, and
- * `expires_in`.
+ * the AAD token endpoint (`login.microsoftonline.com/<tenant>/oauth2/v2.0/token`);
+ * each response is plaintext JSON with `access_token`, `scope`, and `expires_in`.
  *
- * This wraps `window.fetch`, captures the Graph-scoped token from those
- * token-endpoint responses, and stashes it for the adapter to read via
- * `getPreScriptValue`. It also captures a `Bearer` token from any direct
- * `graph.microsoft.com` request, covering the standalone `word.cloud.microsoft`
- * app.
+ * This wraps both `window.fetch` and `XMLHttpRequest`, captures the Graph-scoped
+ * token from those token-endpoint responses, and stashes it for the adapter to
+ * read via `getPreScriptValue`. It also captures a `Bearer` token from any
+ * direct `graph.microsoft.com` request, covering the standalone
+ * `word.cloud.microsoft` app. Capturing the minted token is format-agnostic: it
+ * works regardless of how MSAL keys or encrypts its cache.
  */
 
 interface CapturedGraphToken {
@@ -28,11 +28,23 @@ interface CapturedGraphToken {
 
 const GRAPH_HOSTNAME = 'graph.microsoft.com';
 const TOKEN_ENDPOINT_HOSTNAME = 'login.microsoftonline.com';
-const TOKEN_ENDPOINT_PATH = /\/oauth2\/v2\.0\/token$/i;
+/**
+ * AAD token endpoint paths. Matches both:
+ *   v2: `/<tenant>/oauth2/v2.0/token`  (MSAL.js 2.x default)
+ *   v1: `/<tenant>/oauth2/token`       (MSAL.js 1.x / ADAL.js / legacy SP flows)
+ */
+const TOKEN_ENDPOINT_PATH = /\/oauth2\/(?:v2\.0\/)?token$/i;
 /** Marker used to make the fetch patch idempotent under re-injection. */
-const PATCHED_MARKER = Symbol.for('opentabs.microsoft-word.fetch.patched');
+const FETCH_PATCHED_MARKER = Symbol.for('opentabs.microsoft-word.fetch.patched');
+/** Marker used to make the XHR patch idempotent under re-injection. */
+const XHR_PATCHED_MARKER = Symbol.for('opentabs.microsoft-word.xhr.patched');
 
-/** localStorage mirror so warm reloads and same-origin tabs reuse a captured token. */
+/**
+ * localStorage key the captured token is mirrored to. MSAL only re-mints a
+ * Graph token on a cold load or at refresh time, so warm reloads would
+ * otherwise see nothing. Persisting here lets every same-origin tab reuse a
+ * captured token for its lifetime. The adapter reads the same key.
+ */
 const LS_TOKEN_KEY = '__opentabs_word_graph_token';
 
 const parseUrl = (url: string): URL | null => {
@@ -51,11 +63,10 @@ const isTokenEndpointUrl = (url: string): boolean => {
 };
 
 definePreScript(({ set, log }) => {
-  const g = globalThis as { fetch: typeof fetch & { [PATCHED_MARKER]?: true } };
-  // Idempotency: a second injection into the same realm (hot reload, future
-  // iframe-reuse) must not stack wrappers — that would recurse and double-stash.
-  if (g.fetch[PATCHED_MARKER]) return;
-  const origFetch = g.fetch;
+  const g = globalThis as {
+    fetch: typeof fetch & { [FETCH_PATCHED_MARKER]?: true };
+    XMLHttpRequest: typeof XMLHttpRequest & { [XHR_PATCHED_MARKER]?: true };
+  };
 
   const stash = (token: string, exp: number): void => {
     if (!token || token.length < 16) return;
@@ -94,43 +105,122 @@ definePreScript(({ set, log }) => {
   const scopeGrantsGraph = (scope: string): boolean =>
     scope.split(/\s+/).some(s => parseUrl(s)?.hostname.toLowerCase() === GRAPH_HOSTNAME);
 
+  /** Parse an AAD token-endpoint JSON response and stash any Graph-scoped token. */
   const captureFromTokenResponse = (body: unknown): void => {
     if (!body || typeof body !== 'object') return;
     const data = body as { access_token?: string; scope?: string; expires_in?: number };
     if (typeof data.access_token !== 'string' || typeof data.scope !== 'string') return;
     if (!scopeGrantsGraph(data.scope)) return;
     const ttl = typeof data.expires_in === 'number' && data.expires_in > 0 ? data.expires_in : 3600;
-    stash(data.access_token, Math.floor(Date.now() / 1000) + ttl);
+    const exp = Math.floor(Date.now() / 1000) + ttl;
+    stash(data.access_token, exp);
     log.debug(`[microsoft-word] captured Graph token from AAD token endpoint`);
   };
 
-  const patchedFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+  // --- fetch patch (primary path for MSAL.js auth-code flow + direct Graph) ---
 
-    if (isGraphUrl(url)) {
-      const header =
-        extractBearer(init?.headers) ?? (input instanceof Request ? extractBearer(input.headers) : undefined);
-      if (header?.startsWith('Bearer ') && header.length > 'Bearer '.length) {
-        stash(header.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
+  // Idempotency: a second injection into the same realm (hot reload, future
+  // iframe-reuse) must not stack wrappers — that would recurse and double-stash.
+  if (!g.fetch[FETCH_PATCHED_MARKER]) {
+    const origFetch = g.fetch;
+    const patchedFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+
+      // Secondary path: a Bearer header on a direct Graph request.
+      if (isGraphUrl(url)) {
+        const header =
+          extractBearer(init?.headers) ?? (input instanceof Request ? extractBearer(input.headers) : undefined);
+        if (header?.startsWith('Bearer ') && header.length > 'Bearer '.length) {
+          // No expiry available from a request header; trust it for a short window.
+          stash(header.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
+        }
       }
-    }
 
-    const response = await origFetch(input, init);
+      const response = await origFetch(input, init);
 
-    if (isTokenEndpointUrl(url)) {
-      response
-        .clone()
-        .json()
-        .then(captureFromTokenResponse)
-        .catch(() => {
-          /* non-JSON or read failure — ignore */
-        });
-    }
+      // Primary path: parse the AAD token-endpoint response for a Graph token.
+      if (isTokenEndpointUrl(url)) {
+        response
+          .clone()
+          .json()
+          .then(captureFromTokenResponse)
+          .catch(() => {
+            /* non-JSON or read failure — ignore */
+          });
+      }
 
-    return response;
-  };
+      return response;
+    };
 
-  (patchedFetch as typeof patchedFetch & { [PATCHED_MARKER]: true })[PATCHED_MARKER] = true;
-  g.fetch = patchedFetch as typeof fetch & { [PATCHED_MARKER]?: true };
-  log.info('[microsoft-word] Graph token interceptor installed');
+    (patchedFetch as typeof patchedFetch & { [FETCH_PATCHED_MARKER]: true })[FETCH_PATCHED_MARKER] = true;
+    g.fetch = patchedFetch as typeof fetch & { [FETCH_PATCHED_MARKER]?: true };
+  }
+
+  // --- XMLHttpRequest patch ---
+  //
+  // SharePoint's WAC/Owl framework uses XHR for AAD silent-refresh calls on
+  // some flows (MSAL.js exposes an XHR client for legacy compatibility, and
+  // SP wraps it). Without this hook, refreshed tokens never reach our stash
+  // and the LS mirror goes stale after the first hour.
+
+  if (!g.XMLHttpRequest.prototype || !(g.XMLHttpRequest as unknown as { [k: symbol]: unknown })[XHR_PATCHED_MARKER]) {
+    const Xhr = g.XMLHttpRequest;
+    const origOpen = Xhr.prototype.open;
+    const origSetRequestHeader = Xhr.prototype.setRequestHeader;
+
+    // Per-instance state stashed under a Symbol so we don't collide with page code.
+    const STATE = Symbol('opentabs.microsoft-word.xhr.state');
+    type XhrState = { url: string; bearer?: string };
+    type XhrWithState = XMLHttpRequest & { [STATE]?: XhrState };
+
+    // The XHR.open spec is variadic — `(method, url, async?, user?, password?)`.
+    // The rest tuple here covers the optional tail of the longer overload so
+    // we can forward every form without falling back to `arguments`.
+    type XhrOpenRest = [async?: boolean, username?: string | null, password?: string | null];
+    const patchedOpen = function patchedOpen(
+      this: XhrWithState,
+      method: string,
+      url: string | URL,
+      ...rest: XhrOpenRest
+    ) {
+      const urlStr = typeof url === 'string' ? url : url.href;
+      this[STATE] = { url: urlStr };
+      this.addEventListener('load', () => {
+        const state = this[STATE];
+        if (!state) return;
+
+        // Secondary path: outbound Graph request carrying a Bearer header.
+        if (isGraphUrl(state.url) && state.bearer?.startsWith('Bearer ')) {
+          stash(state.bearer.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
+        }
+
+        // Primary path: AAD token-endpoint response body.
+        if (isTokenEndpointUrl(state.url)) {
+          try {
+            const text = this.responseText;
+            if (text) captureFromTokenResponse(JSON.parse(text));
+          } catch {
+            /* non-JSON or restricted responseText — ignore */
+          }
+        }
+      });
+      // The two `open` overloads (with/without async/user/password) don't
+      // unify when forwarding a rest tuple, so widen `origOpen` to a single
+      // signature that accepts unknown trailing args.
+      const forward = origOpen as (this: XMLHttpRequest, method: string, url: string | URL, ...rest: unknown[]) => void;
+      return forward.call(this, method, urlStr, ...rest);
+    };
+    Xhr.prototype.open = patchedOpen as typeof Xhr.prototype.open;
+
+    Xhr.prototype.setRequestHeader = function patchedSetRequestHeader(this: XhrWithState, name: string, value: string) {
+      if (name.toLowerCase() === 'authorization' && this[STATE]) {
+        this[STATE].bearer = value;
+      }
+      return origSetRequestHeader.call(this, name, value);
+    };
+
+    (g.XMLHttpRequest as unknown as { [k: symbol]: unknown })[XHR_PATCHED_MARKER] = true;
+  }
+
+  log.info('[microsoft-word] Graph token interceptor installed (fetch + XHR)');
 });

--- a/plugins/microsoft-word/src/pre-script.ts
+++ b/plugins/microsoft-word/src/pre-script.ts
@@ -185,25 +185,33 @@ definePreScript(({ set, log }) => {
     ) {
       const urlStr = typeof url === 'string' ? url : url.href;
       this[STATE] = { url: urlStr };
-      this.addEventListener('load', () => {
-        const state = this[STATE];
-        if (!state) return;
+      // `once` is essential: XHR instances are reusable, and we add a listener
+      // on every `open()`. Without it, a reused instance would accumulate a
+      // listener per request and re-run capture for every prior request on each
+      // subsequent response. With it, each request gets exactly one fire.
+      this.addEventListener(
+        'load',
+        () => {
+          const state = this[STATE];
+          if (!state) return;
 
-        // Secondary path: outbound Graph request carrying a Bearer header.
-        if (isGraphUrl(state.url) && state.bearer?.startsWith('Bearer ')) {
-          stash(state.bearer.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
-        }
-
-        // Primary path: AAD token-endpoint response body.
-        if (isTokenEndpointUrl(state.url)) {
-          try {
-            const text = this.responseText;
-            if (text) captureFromTokenResponse(JSON.parse(text));
-          } catch {
-            /* non-JSON or restricted responseText — ignore */
+          // Secondary path: outbound Graph request carrying a Bearer header.
+          if (isGraphUrl(state.url) && state.bearer?.startsWith('Bearer ')) {
+            stash(state.bearer.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
           }
-        }
-      });
+
+          // Primary path: AAD token-endpoint response body.
+          if (isTokenEndpointUrl(state.url)) {
+            try {
+              const text = this.responseText;
+              if (text) captureFromTokenResponse(JSON.parse(text));
+            } catch {
+              /* non-JSON or restricted responseText — ignore */
+            }
+          }
+        },
+        { once: true },
+      );
       // The two `open` overloads (with/without async/user/password) don't
       // unify when forwarding a rest tuple, so widen `origOpen` to a single
       // signature that accepts unknown trailing args.

--- a/plugins/powerpoint/src/pre-script.ts
+++ b/plugins/powerpoint/src/pre-script.ts
@@ -9,14 +9,15 @@ import { definePreScript } from '@opentabs-dev/plugin-sdk/pre-script';
  * page edits through the cross-origin WOPI canvas and MSAL stores its token
  * cache encrypted, so there is no plaintext Graph token in `localStorage`. The
  * page does mint per-resource access tokens on load by POSTing to the AAD token
- * endpoint (`login.microsoftonline.com/<tenant>/oauth2/v2.0/token`) via `fetch`;
- * each response is plaintext JSON with `access_token`, `scope`, and `expires_in`.
+ * endpoint (`login.microsoftonline.com/<tenant>/oauth2/v2.0/token`); each
+ * response is plaintext JSON with `access_token`, `scope`, and `expires_in`.
  *
- * This wraps `window.fetch`, captures the Graph-scoped token from those
- * token-endpoint responses, and stashes it for the adapter to read via
- * `getPreScriptValue`. It also captures a `Bearer` token from any direct
- * `graph.microsoft.com` request, covering the standalone
- * `powerpoint.cloud.microsoft` app.
+ * This wraps both `window.fetch` and `XMLHttpRequest`, captures the Graph-scoped
+ * token from those token-endpoint responses, and stashes it for the adapter to
+ * read via `getPreScriptValue`. It also captures a `Bearer` token from any
+ * direct `graph.microsoft.com` request, covering the standalone
+ * `powerpoint.cloud.microsoft` app. Capturing the minted token is
+ * format-agnostic: it works regardless of how MSAL keys or encrypts its cache.
  */
 
 interface CapturedGraphToken {
@@ -27,11 +28,23 @@ interface CapturedGraphToken {
 
 const GRAPH_HOSTNAME = 'graph.microsoft.com';
 const TOKEN_ENDPOINT_HOSTNAME = 'login.microsoftonline.com';
-const TOKEN_ENDPOINT_PATH = /\/oauth2\/v2\.0\/token$/i;
+/**
+ * AAD token endpoint paths. Matches both:
+ *   v2: `/<tenant>/oauth2/v2.0/token`  (MSAL.js 2.x default)
+ *   v1: `/<tenant>/oauth2/token`       (MSAL.js 1.x / ADAL.js / legacy SP flows)
+ */
+const TOKEN_ENDPOINT_PATH = /\/oauth2\/(?:v2\.0\/)?token$/i;
 /** Marker used to make the fetch patch idempotent under re-injection. */
-const PATCHED_MARKER = Symbol.for('opentabs.powerpoint.fetch.patched');
+const FETCH_PATCHED_MARKER = Symbol.for('opentabs.powerpoint.fetch.patched');
+/** Marker used to make the XHR patch idempotent under re-injection. */
+const XHR_PATCHED_MARKER = Symbol.for('opentabs.powerpoint.xhr.patched');
 
-/** localStorage mirror so warm reloads and same-origin tabs reuse a captured token. */
+/**
+ * localStorage key the captured token is mirrored to. MSAL only re-mints a
+ * Graph token on a cold load or at refresh time, so warm reloads would
+ * otherwise see nothing. Persisting here lets every same-origin tab reuse a
+ * captured token for its lifetime. The adapter reads the same key.
+ */
 const LS_TOKEN_KEY = '__opentabs_powerpoint_graph_token';
 
 const parseUrl = (url: string): URL | null => {
@@ -50,11 +63,10 @@ const isTokenEndpointUrl = (url: string): boolean => {
 };
 
 definePreScript(({ set, log }) => {
-  const g = globalThis as { fetch: typeof fetch & { [PATCHED_MARKER]?: true } };
-  // Idempotency: a second injection into the same realm (hot reload, future
-  // iframe-reuse) must not stack wrappers — that would recurse and double-stash.
-  if (g.fetch[PATCHED_MARKER]) return;
-  const origFetch = g.fetch;
+  const g = globalThis as {
+    fetch: typeof fetch & { [FETCH_PATCHED_MARKER]?: true };
+    XMLHttpRequest: typeof XMLHttpRequest & { [XHR_PATCHED_MARKER]?: true };
+  };
 
   const stash = (token: string, exp: number): void => {
     if (!token || token.length < 16) return;
@@ -93,43 +105,122 @@ definePreScript(({ set, log }) => {
   const scopeGrantsGraph = (scope: string): boolean =>
     scope.split(/\s+/).some(s => parseUrl(s)?.hostname.toLowerCase() === GRAPH_HOSTNAME);
 
+  /** Parse an AAD token-endpoint JSON response and stash any Graph-scoped token. */
   const captureFromTokenResponse = (body: unknown): void => {
     if (!body || typeof body !== 'object') return;
     const data = body as { access_token?: string; scope?: string; expires_in?: number };
     if (typeof data.access_token !== 'string' || typeof data.scope !== 'string') return;
     if (!scopeGrantsGraph(data.scope)) return;
     const ttl = typeof data.expires_in === 'number' && data.expires_in > 0 ? data.expires_in : 3600;
-    stash(data.access_token, Math.floor(Date.now() / 1000) + ttl);
+    const exp = Math.floor(Date.now() / 1000) + ttl;
+    stash(data.access_token, exp);
     log.debug(`[powerpoint] captured Graph token from AAD token endpoint`);
   };
 
-  const patchedFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+  // --- fetch patch (primary path for MSAL.js auth-code flow + direct Graph) ---
 
-    if (isGraphUrl(url)) {
-      const header =
-        extractBearer(init?.headers) ?? (input instanceof Request ? extractBearer(input.headers) : undefined);
-      if (header?.startsWith('Bearer ') && header.length > 'Bearer '.length) {
-        stash(header.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
+  // Idempotency: a second injection into the same realm (hot reload, future
+  // iframe-reuse) must not stack wrappers — that would recurse and double-stash.
+  if (!g.fetch[FETCH_PATCHED_MARKER]) {
+    const origFetch = g.fetch;
+    const patchedFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+
+      // Secondary path: a Bearer header on a direct Graph request.
+      if (isGraphUrl(url)) {
+        const header =
+          extractBearer(init?.headers) ?? (input instanceof Request ? extractBearer(input.headers) : undefined);
+        if (header?.startsWith('Bearer ') && header.length > 'Bearer '.length) {
+          // No expiry available from a request header; trust it for a short window.
+          stash(header.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
+        }
       }
-    }
 
-    const response = await origFetch(input, init);
+      const response = await origFetch(input, init);
 
-    if (isTokenEndpointUrl(url)) {
-      response
-        .clone()
-        .json()
-        .then(captureFromTokenResponse)
-        .catch(() => {
-          /* non-JSON or read failure — ignore */
-        });
-    }
+      // Primary path: parse the AAD token-endpoint response for a Graph token.
+      if (isTokenEndpointUrl(url)) {
+        response
+          .clone()
+          .json()
+          .then(captureFromTokenResponse)
+          .catch(() => {
+            /* non-JSON or read failure — ignore */
+          });
+      }
 
-    return response;
-  };
+      return response;
+    };
 
-  (patchedFetch as typeof patchedFetch & { [PATCHED_MARKER]: true })[PATCHED_MARKER] = true;
-  g.fetch = patchedFetch as typeof fetch & { [PATCHED_MARKER]?: true };
-  log.info('[powerpoint] Graph token interceptor installed');
+    (patchedFetch as typeof patchedFetch & { [FETCH_PATCHED_MARKER]: true })[FETCH_PATCHED_MARKER] = true;
+    g.fetch = patchedFetch as typeof fetch & { [FETCH_PATCHED_MARKER]?: true };
+  }
+
+  // --- XMLHttpRequest patch ---
+  //
+  // SharePoint's WAC/Owl framework uses XHR for AAD silent-refresh calls on
+  // some flows (MSAL.js exposes an XHR client for legacy compatibility, and
+  // SP wraps it). Without this hook, refreshed tokens never reach our stash
+  // and the LS mirror goes stale after the first hour.
+
+  if (!g.XMLHttpRequest.prototype || !(g.XMLHttpRequest as unknown as { [k: symbol]: unknown })[XHR_PATCHED_MARKER]) {
+    const Xhr = g.XMLHttpRequest;
+    const origOpen = Xhr.prototype.open;
+    const origSetRequestHeader = Xhr.prototype.setRequestHeader;
+
+    // Per-instance state stashed under a Symbol so we don't collide with page code.
+    const STATE = Symbol('opentabs.powerpoint.xhr.state');
+    type XhrState = { url: string; bearer?: string };
+    type XhrWithState = XMLHttpRequest & { [STATE]?: XhrState };
+
+    // The XHR.open spec is variadic — `(method, url, async?, user?, password?)`.
+    // The rest tuple here covers the optional tail of the longer overload so
+    // we can forward every form without falling back to `arguments`.
+    type XhrOpenRest = [async?: boolean, username?: string | null, password?: string | null];
+    const patchedOpen = function patchedOpen(
+      this: XhrWithState,
+      method: string,
+      url: string | URL,
+      ...rest: XhrOpenRest
+    ) {
+      const urlStr = typeof url === 'string' ? url : url.href;
+      this[STATE] = { url: urlStr };
+      this.addEventListener('load', () => {
+        const state = this[STATE];
+        if (!state) return;
+
+        // Secondary path: outbound Graph request carrying a Bearer header.
+        if (isGraphUrl(state.url) && state.bearer?.startsWith('Bearer ')) {
+          stash(state.bearer.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
+        }
+
+        // Primary path: AAD token-endpoint response body.
+        if (isTokenEndpointUrl(state.url)) {
+          try {
+            const text = this.responseText;
+            if (text) captureFromTokenResponse(JSON.parse(text));
+          } catch {
+            /* non-JSON or restricted responseText — ignore */
+          }
+        }
+      });
+      // The two `open` overloads (with/without async/user/password) don't
+      // unify when forwarding a rest tuple, so widen `origOpen` to a single
+      // signature that accepts unknown trailing args.
+      const forward = origOpen as (this: XMLHttpRequest, method: string, url: string | URL, ...rest: unknown[]) => void;
+      return forward.call(this, method, urlStr, ...rest);
+    };
+    Xhr.prototype.open = patchedOpen as typeof Xhr.prototype.open;
+
+    Xhr.prototype.setRequestHeader = function patchedSetRequestHeader(this: XhrWithState, name: string, value: string) {
+      if (name.toLowerCase() === 'authorization' && this[STATE]) {
+        this[STATE].bearer = value;
+      }
+      return origSetRequestHeader.call(this, name, value);
+    };
+
+    (g.XMLHttpRequest as unknown as { [k: symbol]: unknown })[XHR_PATCHED_MARKER] = true;
+  }
+
+  log.info('[powerpoint] Graph token interceptor installed (fetch + XHR)');
 });

--- a/plugins/powerpoint/src/pre-script.ts
+++ b/plugins/powerpoint/src/pre-script.ts
@@ -185,25 +185,33 @@ definePreScript(({ set, log }) => {
     ) {
       const urlStr = typeof url === 'string' ? url : url.href;
       this[STATE] = { url: urlStr };
-      this.addEventListener('load', () => {
-        const state = this[STATE];
-        if (!state) return;
+      // `once` is essential: XHR instances are reusable, and we add a listener
+      // on every `open()`. Without it, a reused instance would accumulate a
+      // listener per request and re-run capture for every prior request on each
+      // subsequent response. With it, each request gets exactly one fire.
+      this.addEventListener(
+        'load',
+        () => {
+          const state = this[STATE];
+          if (!state) return;
 
-        // Secondary path: outbound Graph request carrying a Bearer header.
-        if (isGraphUrl(state.url) && state.bearer?.startsWith('Bearer ')) {
-          stash(state.bearer.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
-        }
-
-        // Primary path: AAD token-endpoint response body.
-        if (isTokenEndpointUrl(state.url)) {
-          try {
-            const text = this.responseText;
-            if (text) captureFromTokenResponse(JSON.parse(text));
-          } catch {
-            /* non-JSON or restricted responseText — ignore */
+          // Secondary path: outbound Graph request carrying a Bearer header.
+          if (isGraphUrl(state.url) && state.bearer?.startsWith('Bearer ')) {
+            stash(state.bearer.slice('Bearer '.length), Math.floor(Date.now() / 1000) + 600);
           }
-        }
-      });
+
+          // Primary path: AAD token-endpoint response body.
+          if (isTokenEndpointUrl(state.url)) {
+            try {
+              const text = this.responseText;
+              if (text) captureFromTokenResponse(JSON.parse(text));
+            } catch {
+              /* non-JSON or restricted responseText — ignore */
+            }
+          }
+        },
+        { once: true },
+      );
       // The two `open` overloads (with/without async/user/password) don't
       // unify when forwarding a rest tuple, so widen `origOpen` to a single
       // signature that accepts unknown trailing args.


### PR DESCRIPTION
## Problem

On a long-lived SharePoint-hosted Office tab, the **PowerPoint** and **Word** plugins fail every tool call with `AUTH_ERROR — Not authenticated` after roughly an hour, even though the adapter is injected and ready.

Root cause: both pre-scripts only wrapped `window.fetch`. They capture the Graph token minted on a **cold page load**, but SharePoint's WAC/Owl framework performs its subsequent **silent token refreshes over `XMLHttpRequest`**, not `fetch`. So the captured token (and its `localStorage` mirror) is never refreshed — it expires after the first hour and the adapter correctly rejects the stale token, leaving the plugin unauthenticated until the page is manually reloaded.

This was diagnosed live: the pre-script namespace held a token with `exp` ~40 minutes in the past.

## Fix

Port the interceptor pattern already proven in `excel-online`:

- **Wrap `XMLHttpRequest` in addition to `fetch`**, so Graph-scoped tokens are captured from AAD token-endpoint responses for the tab's entire lifetime — including the hourly silent refresh.
- **Broaden the token-endpoint matcher** to accept the v1 path (`/oauth2/token`) alongside v2 (`/oauth2/v2.0/token`).

Both patches are idempotent under re-injection (separate `Symbol.for` markers for fetch and XHR). No behavior change on the standalone `*.cloud.microsoft` apps.

## Verification

Verified end-to-end on a live SharePoint-hosted presentation:

- Before: captured token expired (`exp` in the past) → `get_current_user` returned `AUTH_ERROR`.
- After rebuild + reload: both `fetchPatched` and `xhrPatched` active, fresh token captured (~87 min validity), `get_current_user` and `get_slides` (14 slides) both succeed.
- `npm run build`, lint, and format:check pass for both plugins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Microsoft Word and PowerPoint plugins to capture and persist authentication tokens more reliably across both modern and legacy Azure AD token endpoint formats.
  * Improved interception coverage for both network fetch requests and XMLHttpRequest traffic, including direct Graph bearer requests and token-endpoint JSON responses.
  * Token handling now better validates Graph-scoped tokens and computes expiration more robustly when values are missing or malformed.
* **Documentation**
  * Updated pre-script documentation to reflect the new, format-agnostic token capture behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->