### PR TITLE
feat(microsoft-word): SharePoint auth recovery + editing robustness

### DIFF
--- a/plugins/microsoft-word/src/index.ts
+++ b/plugins/microsoft-word/src/index.ts
@@ -21,6 +21,7 @@ import { listRecentDocuments } from './tools/list-recent-documents.js';
 import { listSharedWithMe } from './tools/list-shared-with-me.js';
 import { listVersions } from './tools/list-versions.js';
 import { moveItem } from './tools/move-item.js';
+import { reauthenticate } from './tools/reauthenticate.js';
 import { renameItem } from './tools/rename-item.js';
 import { replaceTextInDocument } from './tools/replace-text-in-document.js';
 import { restoreVersion } from './tools/restore-version.js';
@@ -38,6 +39,7 @@ class MicrosoftWordPlugin extends OpenTabsPlugin {
   readonly tools: ToolDefinition[] = [
     // Account
     getCurrentUser,
+    reauthenticate,
     // Drive
     getDrive,
     // Documents — the core document editing tools

--- a/plugins/microsoft-word/src/microsoft-word-api.ts
+++ b/plugins/microsoft-word/src/microsoft-word-api.ts
@@ -1,6 +1,7 @@
 import {
   ToolError,
   buildQueryString,
+  clearAuthCache,
   findLocalStorageEntry,
   getCurrentUrl,
   getLocalStorage,
@@ -108,7 +109,7 @@ const getToken = (): string | null => getCapturedToken() ?? getMsalToken();
 export const getGraphToken = (): string => {
   const token = getToken();
   if (token) return token;
-  return authError('Not authenticated — please sign in to Microsoft 365.');
+  return authError(NOT_AUTHENTICATED_MESSAGE);
 };
 
 export const isAuthenticated = (): boolean => getToken() !== null;
@@ -137,8 +138,19 @@ export const isSharePointDocument = (): boolean => {
  */
 const SP_REAUTH_HINT = 'Call `microsoft-word_reauthenticate` to recover.';
 
-/** Throw an AUTH_ERROR, appending the reauth hint on SharePoint documents. */
+/** User-facing message when no Graph token is available at all. */
+export const NOT_AUTHENTICATED_MESSAGE = 'Not authenticated — please sign in to Microsoft 365.';
+
+/** User-facing message when Graph rejects the token as expired (401/403). */
+export const AUTH_EXPIRED_MESSAGE = 'Authentication expired — please refresh the page.';
+
+/**
+ * Throw an AUTH_ERROR, appending the reauth hint on SharePoint documents.
+ * Clears the adapter's cached token first so the next call re-reads fresh auth
+ * state — every auth failure path resets the cache through this single helper.
+ */
 export const authError = (msg: string): never => {
+  clearAuthCache('microsoft-word');
   throw ToolError.auth(isSharePointDocument() ? `${msg} ${SP_REAUTH_HINT}` : msg);
 };
 
@@ -223,7 +235,7 @@ export const api = async <T>(
   } = {},
 ): Promise<T> => {
   const token = getToken();
-  if (!token) authError('Not authenticated — please sign in to Microsoft 365.');
+  if (!token) authError(NOT_AUTHENTICATED_MESSAGE);
 
   const qs = options.query ? buildQueryString(options.query) : '';
   const url = qs ? `${GRAPH_API_BASE}${endpoint}?${qs}` : `${GRAPH_API_BASE}${endpoint}`;
@@ -269,7 +281,7 @@ export const api = async <T>(
   }
 
   if (response.status === 401 || response.status === 403) {
-    authError('Authentication expired — please refresh the page.');
+    authError(AUTH_EXPIRED_MESSAGE);
   }
 
   if (response.status === 404) {

--- a/plugins/microsoft-word/src/microsoft-word-api.ts
+++ b/plugins/microsoft-word/src/microsoft-word-api.ts
@@ -134,9 +134,9 @@ export const isSharePointDocument = (): boolean => {
  * Trailing guidance appended to AUTH_ERROR messages on SharePoint/OneDrive
  * documents. MSAL's encrypted cache means we can't recover in-place — the only
  * reliable path is to clear MSAL state and reload, which the
- * `microsoft-word_reauthenticate` tool does.
+ * `microsoft-word__reauthenticate` tool does.
  */
-const SP_REAUTH_HINT = 'Call `microsoft-word_reauthenticate` to recover.';
+const SP_REAUTH_HINT = 'Call `microsoft-word__reauthenticate` to recover.';
 
 /** User-facing message when no Graph token is available at all. */
 export const NOT_AUTHENTICATED_MESSAGE = 'Not authenticated — please sign in to Microsoft 365.';

--- a/plugins/microsoft-word/src/microsoft-word-api.ts
+++ b/plugins/microsoft-word/src/microsoft-word-api.ts
@@ -107,8 +107,8 @@ const getToken = (): string | null => getCapturedToken() ?? getMsalToken();
  */
 export const getGraphToken = (): string => {
   const token = getToken();
-  if (!token) throw ToolError.auth('Not authenticated — please sign in to Microsoft 365.');
-  return token;
+  if (token) return token;
+  return authError('Not authenticated — please sign in to Microsoft 365.');
 };
 
 export const isAuthenticated = (): boolean => getToken() !== null;
@@ -128,6 +128,30 @@ export const isSharePointDocument = (): boolean => {
     return false;
   }
 };
+
+/**
+ * Trailing guidance appended to AUTH_ERROR messages on SharePoint/OneDrive
+ * documents. MSAL's encrypted cache means we can't recover in-place — the only
+ * reliable path is to clear MSAL state and reload, which the
+ * `microsoft-word_reauthenticate` tool does.
+ */
+const SP_REAUTH_HINT = 'Call `microsoft-word_reauthenticate` to recover.';
+
+/** Throw an AUTH_ERROR, appending the reauth hint on SharePoint documents. */
+export const authError = (msg: string): never => {
+  throw ToolError.auth(isSharePointDocument() ? `${msg} ${SP_REAUTH_HINT}` : msg);
+};
+
+/**
+ * Guidance for HTTP 423 from Graph `/content`. The file is held by a WOPI
+ * co-authoring lock — almost always because it is open in the Word web editor
+ * in this very browser. Graph cannot overwrite a locked file, so the only path
+ * is to close the editor (or wait for the lock to lapse) and retry.
+ */
+export const FILE_LOCKED_MESSAGE =
+  'The document is locked because it is open in the Word web editor (or another co-authoring session), ' +
+  'so Microsoft Graph cannot save changes to it. Close the editor tab — or wait ~30–60 seconds after closing ' +
+  'for the lock to release — then retry.';
 
 interface DocumentContext {
   driveId: string;
@@ -199,7 +223,7 @@ export const api = async <T>(
   } = {},
 ): Promise<T> => {
   const token = getToken();
-  if (!token) throw ToolError.auth('Not authenticated — please sign in to Microsoft 365.');
+  if (!token) authError('Not authenticated — please sign in to Microsoft 365.');
 
   const qs = options.query ? buildQueryString(options.query) : '';
   const url = qs ? `${GRAPH_API_BASE}${endpoint}?${qs}` : `${GRAPH_API_BASE}${endpoint}`;
@@ -245,7 +269,7 @@ export const api = async <T>(
   }
 
   if (response.status === 401 || response.status === 403) {
-    throw ToolError.auth('Authentication expired — please refresh the page.');
+    authError('Authentication expired — please refresh the page.');
   }
 
   if (response.status === 404) {

--- a/plugins/microsoft-word/src/tools/copy-item.ts
+++ b/plugins/microsoft-word/src/tools/copy-item.ts
@@ -1,6 +1,6 @@
-import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
+import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { authError, getGraphToken } from '../microsoft-word-api.js';
+import { AUTH_EXPIRED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 
@@ -49,8 +49,7 @@ export const copyItem = defineTool({
     }
 
     if (response.status === 401 || response.status === 403) {
-      clearAuthCache('microsoft-word');
-      authError('Authentication expired — please refresh the page.');
+      authError(AUTH_EXPIRED_MESSAGE);
     }
 
     if (response.status === 404) {

--- a/plugins/microsoft-word/src/tools/copy-item.ts
+++ b/plugins/microsoft-word/src/tools/copy-item.ts
@@ -1,6 +1,6 @@
 import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { getGraphToken } from '../microsoft-word-api.js';
+import { authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 
@@ -50,7 +50,7 @@ export const copyItem = defineTool({
 
     if (response.status === 401 || response.status === 403) {
       clearAuthCache('microsoft-word');
-      throw ToolError.auth('Authentication expired — please refresh the page.');
+      authError('Authentication expired — please refresh the page.');
     }
 
     if (response.status === 404) {

--- a/plugins/microsoft-word/src/tools/create-document.ts
+++ b/plugins/microsoft-word/src/tools/create-document.ts
@@ -1,7 +1,7 @@
-import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
+import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { buildDocx } from '../docx-utils.js';
-import { authError, getGraphToken } from '../microsoft-word-api.js';
+import { AUTH_EXPIRED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 import { type RawDriveItem, driveItemSchema, mapDriveItem } from './schemas.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
@@ -57,8 +57,7 @@ export const createDocument = defineTool({
     }
 
     if (response.status === 401 || response.status === 403) {
-      clearAuthCache('microsoft-word');
-      authError('Authentication expired — please refresh the page.');
+      authError(AUTH_EXPIRED_MESSAGE);
     }
 
     if (!response.ok) {

--- a/plugins/microsoft-word/src/tools/create-document.ts
+++ b/plugins/microsoft-word/src/tools/create-document.ts
@@ -1,7 +1,7 @@
 import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { buildDocx } from '../docx-utils.js';
-import { getGraphToken } from '../microsoft-word-api.js';
+import { authError, getGraphToken } from '../microsoft-word-api.js';
 import { type RawDriveItem, driveItemSchema, mapDriveItem } from './schemas.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
@@ -58,7 +58,7 @@ export const createDocument = defineTool({
 
     if (response.status === 401 || response.status === 403) {
       clearAuthCache('microsoft-word');
-      throw ToolError.auth('Authentication expired — please refresh the page.');
+      authError('Authentication expired — please refresh the page.');
     }
 
     if (!response.ok) {

--- a/plugins/microsoft-word/src/tools/docx-edit-helpers.ts
+++ b/plugins/microsoft-word/src/tools/docx-edit-helpers.ts
@@ -1,9 +1,9 @@
 /**
  * Shared helpers for tools that download, modify, and re-upload .docx files.
  */
-import { ToolError, clearAuthCache } from '@opentabs-dev/plugin-sdk';
+import { ToolError } from '@opentabs-dev/plugin-sdk';
 import { type ZipEntry, extractAllZipEntries, rebuildZip } from '../docx-utils.js';
-import { FILE_LOCKED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
+import { AUTH_EXPIRED_MESSAGE, FILE_LOCKED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
@@ -107,8 +107,7 @@ async function fetchWithErrorHandling(url: string, init: RequestInit): Promise<R
   }
 
   if (response.status === 401 || response.status === 403) {
-    clearAuthCache('microsoft-word');
-    authError('Authentication expired — please refresh the page.');
+    authError(AUTH_EXPIRED_MESSAGE);
   }
   if (response.status === 423) {
     throw ToolError.validation(FILE_LOCKED_MESSAGE);

--- a/plugins/microsoft-word/src/tools/docx-edit-helpers.ts
+++ b/plugins/microsoft-word/src/tools/docx-edit-helpers.ts
@@ -3,7 +3,7 @@
  */
 import { ToolError, clearAuthCache } from '@opentabs-dev/plugin-sdk';
 import { type ZipEntry, extractAllZipEntries, rebuildZip } from '../docx-utils.js';
-import { getGraphToken } from '../microsoft-word-api.js';
+import { FILE_LOCKED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
@@ -108,7 +108,10 @@ async function fetchWithErrorHandling(url: string, init: RequestInit): Promise<R
 
   if (response.status === 401 || response.status === 403) {
     clearAuthCache('microsoft-word');
-    throw ToolError.auth('Authentication expired — please refresh the page.');
+    authError('Authentication expired — please refresh the page.');
+  }
+  if (response.status === 423) {
+    throw ToolError.validation(FILE_LOCKED_MESSAGE);
   }
   if (response.status === 404) {
     throw ToolError.notFound('Document not found.');

--- a/plugins/microsoft-word/src/tools/get-document-text.ts
+++ b/plugins/microsoft-word/src/tools/get-document-text.ts
@@ -1,7 +1,7 @@
-import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
+import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { extractTextFromDocumentXml, extractZipEntry } from '../docx-utils.js';
-import { authError, getGraphToken } from '../microsoft-word-api.js';
+import { AUTH_EXPIRED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 
@@ -33,8 +33,7 @@ export const getDocumentText = defineTool({
       });
 
       if (metaResp.status === 401 || metaResp.status === 403) {
-        clearAuthCache('microsoft-word');
-        authError('Authentication expired — please refresh the page.');
+        authError(AUTH_EXPIRED_MESSAGE);
       }
       if (metaResp.status === 404) {
         throw ToolError.notFound('Document not found.');

--- a/plugins/microsoft-word/src/tools/get-document-text.ts
+++ b/plugins/microsoft-word/src/tools/get-document-text.ts
@@ -1,7 +1,7 @@
 import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
 import { extractTextFromDocumentXml, extractZipEntry } from '../docx-utils.js';
-import { getGraphToken } from '../microsoft-word-api.js';
+import { authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 
@@ -34,7 +34,7 @@ export const getDocumentText = defineTool({
 
       if (metaResp.status === 401 || metaResp.status === 403) {
         clearAuthCache('microsoft-word');
-        throw ToolError.auth('Authentication expired — please refresh the page.');
+        authError('Authentication expired — please refresh the page.');
       }
       if (metaResp.status === 404) {
         throw ToolError.notFound('Document not found.');

--- a/plugins/microsoft-word/src/tools/get-file-content.ts
+++ b/plugins/microsoft-word/src/tools/get-file-content.ts
@@ -1,6 +1,6 @@
-import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
+import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { authError, getGraphToken } from '../microsoft-word-api.js';
+import { AUTH_EXPIRED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 
@@ -32,8 +32,7 @@ export const getFileContent = defineTool({
       });
 
       if (metaResp.status === 401 || metaResp.status === 403) {
-        clearAuthCache('microsoft-word');
-        authError('Authentication expired — please refresh the page.');
+        authError(AUTH_EXPIRED_MESSAGE);
       }
       if (metaResp.status === 404) {
         throw ToolError.notFound('File not found.');

--- a/plugins/microsoft-word/src/tools/get-file-content.ts
+++ b/plugins/microsoft-word/src/tools/get-file-content.ts
@@ -1,6 +1,6 @@
 import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { getGraphToken } from '../microsoft-word-api.js';
+import { authError, getGraphToken } from '../microsoft-word-api.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
 
@@ -33,7 +33,7 @@ export const getFileContent = defineTool({
 
       if (metaResp.status === 401 || metaResp.status === 403) {
         clearAuthCache('microsoft-word');
-        throw ToolError.auth('Authentication expired — please refresh the page.');
+        authError('Authentication expired — please refresh the page.');
       }
       if (metaResp.status === 404) {
         throw ToolError.notFound('File not found.');

--- a/plugins/microsoft-word/src/tools/list-shared-with-me.ts
+++ b/plugins/microsoft-word/src/tools/list-shared-with-me.ts
@@ -17,12 +17,15 @@ export const listSharedWithMe = defineTool({
     items: z.array(driveItemSchema).describe('Shared files and folders'),
   }),
   handle: async ({ top }) => {
+    const limit = top ?? 10;
+    // Graph ignores $top on /me/drive/sharedWithMe (it returns the full set), so
+    // enforce the limit client-side to keep the response bounded.
     const data = await api<{ value: RawDriveItem[] }>('/me/drive/sharedWithMe', {
       query: {
-        $top: top ?? 10,
+        $top: limit,
         $select: 'id,name,size,folder,file,webUrl,createdDateTime,lastModifiedDateTime,parentReference,description',
       },
     });
-    return { items: data.value.map(mapDriveItem) };
+    return { items: (data.value ?? []).slice(0, limit).map(mapDriveItem) };
   },
 });

--- a/plugins/microsoft-word/src/tools/reauthenticate.ts
+++ b/plugins/microsoft-word/src/tools/reauthenticate.ts
@@ -19,8 +19,8 @@ const LS_TOKEN_KEY = '__opentabs_word_graph_token';
  * which the pre-script catches. SSO cookies stay intact, so the
  * re-acquisition is silent (no sign-in UI).
  *
- * Caller protocol: when `microsoft-word_*` tools return an `AUTH_ERROR` whose
- * message ends with "Call `microsoft-word_reauthenticate` to recover", invoke
+ * Caller protocol: when `microsoft-word__*` tools return an `AUTH_ERROR` whose
+ * message ends with "Call `microsoft-word__reauthenticate` to recover", invoke
  * this tool, wait for the tab to reload (~5 seconds), then retry the
  * original operation.
  */

--- a/plugins/microsoft-word/src/tools/reauthenticate.ts
+++ b/plugins/microsoft-word/src/tools/reauthenticate.ts
@@ -1,0 +1,82 @@
+import { clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { isSharePointDocument } from '../microsoft-word-api.js';
+
+/** localStorage key the pre-script mirrors the captured Graph token to. */
+const LS_TOKEN_KEY = '__opentabs_word_graph_token';
+
+/**
+ * Recover from a stale Graph token on SharePoint/OneDrive-hosted documents.
+ *
+ * On those pages the Graph token is captured by the pre-script from MSAL's
+ * AAD token-endpoint responses. After the captured token expires (~1h), MSAL
+ * keeps minting fresh tokens silently — but reads them from its encrypted
+ * cache without re-hitting the token endpoint, so the pre-script's
+ * window-of-opportunity has closed and the LS mirror goes stale.
+ *
+ * The only reliable recovery is to clear MSAL's localStorage state so that
+ * the next page load forces MSAL to re-acquire from the token endpoint —
+ * which the pre-script catches. SSO cookies stay intact, so the
+ * re-acquisition is silent (no sign-in UI).
+ *
+ * Caller protocol: when `microsoft-word_*` tools return an `AUTH_ERROR` whose
+ * message ends with "Call `microsoft-word_reauthenticate` to recover", invoke
+ * this tool, wait for the tab to reload (~5 seconds), then retry the
+ * original operation.
+ */
+export const reauthenticate = defineTool({
+  name: 'reauthenticate',
+  displayName: 'Reauthenticate',
+  description:
+    'Clear cached MSAL state and reload the SharePoint/OneDrive tab to force a fresh Microsoft Graph token. ' +
+    'Use this when another Word tool returns an authentication error pointing at this tool. ' +
+    'After invoking, wait ~5 seconds for the tab to finish reloading, then retry the original operation.',
+  summary: 'Force a fresh Microsoft Graph token by clearing stale MSAL state and reloading the tab',
+  icon: 'refresh-cw',
+  group: 'Account',
+  input: z.object({}),
+  output: z.object({
+    status: z.enum(['reloading', 'skipped']),
+    message: z.string(),
+  }),
+  handle: async () => {
+    // Only meaningful on SharePoint/OneDrive — the standalone
+    // `word.cloud.microsoft` app has no encrypted-cache problem, so
+    // there is nothing to clear and no reload to perform.
+    if (!isSharePointDocument()) {
+      return {
+        status: 'skipped' as const,
+        message:
+          'This tab is not a SharePoint/OneDrive document — reauthenticate has no effect here. If you are seeing AUTH_ERROR on a standalone word.cloud.microsoft tab, sign in to Microsoft 365 in this browser session.',
+      };
+    }
+
+    // Clear every MSAL entry and our own captured-token mirror. We sweep by
+    // prefix rather than by exact key because MSAL's enterprise format
+    // namespaces each entry with a home-account-id and tenant id we don't
+    // know up front. Use a two-pass delete (collect then remove) so we
+    // don't perturb the iteration mid-flight.
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && (k.startsWith('msal.') || k === LS_TOKEN_KEY)) keys.push(k);
+    }
+    for (const k of keys) localStorage.removeItem(k);
+
+    // Drop the adapter's cached token too so the next tool call after reload
+    // looks at the freshly captured value.
+    clearAuthCache('microsoft-word');
+
+    // Reload after the response is sent. The setTimeout gives the dispatch
+    // pipeline a tick to serialize our return value before the page goes
+    // away. `location.reload()` itself is fire-and-forget — the adapter
+    // process dies with the page.
+    setTimeout(() => location.reload(), 50);
+
+    return {
+      status: 'reloading' as const,
+      message:
+        'Cleared cached MSAL state and reloading the tab. The pre-script will capture a fresh Graph token from the next AAD round-trip (silent via SSO cookies). Wait ~5 seconds, then retry the original tool call.',
+    };
+  },
+});

--- a/plugins/microsoft-word/src/tools/update-file-content.ts
+++ b/plugins/microsoft-word/src/tools/update-file-content.ts
@@ -1,6 +1,6 @@
-import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
+import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { FILE_LOCKED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
+import { AUTH_EXPIRED_MESSAGE, FILE_LOCKED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 import { type RawDriveItem, driveItemSchema, mapDriveItem } from './schemas.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
@@ -44,8 +44,7 @@ export const updateFileContent = defineTool({
     }
 
     if (response.status === 401 || response.status === 403) {
-      clearAuthCache('microsoft-word');
-      authError('Authentication expired — please refresh the page.');
+      authError(AUTH_EXPIRED_MESSAGE);
     }
 
     if (response.status === 423) {

--- a/plugins/microsoft-word/src/tools/update-file-content.ts
+++ b/plugins/microsoft-word/src/tools/update-file-content.ts
@@ -1,6 +1,6 @@
 import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { getGraphToken } from '../microsoft-word-api.js';
+import { FILE_LOCKED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 import { type RawDriveItem, driveItemSchema, mapDriveItem } from './schemas.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
@@ -45,7 +45,11 @@ export const updateFileContent = defineTool({
 
     if (response.status === 401 || response.status === 403) {
       clearAuthCache('microsoft-word');
-      throw ToolError.auth('Authentication expired — please refresh the page.');
+      authError('Authentication expired — please refresh the page.');
+    }
+
+    if (response.status === 423) {
+      throw ToolError.validation(FILE_LOCKED_MESSAGE);
     }
 
     if (response.status === 404) {

--- a/plugins/microsoft-word/src/tools/upload-file.ts
+++ b/plugins/microsoft-word/src/tools/upload-file.ts
@@ -1,6 +1,6 @@
-import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
+import { ToolError, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { authError, getGraphToken } from '../microsoft-word-api.js';
+import { AUTH_EXPIRED_MESSAGE, authError, getGraphToken } from '../microsoft-word-api.js';
 import { type RawDriveItem, driveItemSchema, mapDriveItem } from './schemas.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
@@ -46,8 +46,7 @@ export const uploadFile = defineTool({
     }
 
     if (response.status === 401 || response.status === 403) {
-      clearAuthCache('microsoft-word');
-      authError('Authentication expired — please refresh the page.');
+      authError(AUTH_EXPIRED_MESSAGE);
     }
 
     if (!response.ok) {

--- a/plugins/microsoft-word/src/tools/upload-file.ts
+++ b/plugins/microsoft-word/src/tools/upload-file.ts
@@ -1,6 +1,6 @@
 import { ToolError, clearAuthCache, defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
-import { getGraphToken } from '../microsoft-word-api.js';
+import { authError, getGraphToken } from '../microsoft-word-api.js';
 import { type RawDriveItem, driveItemSchema, mapDriveItem } from './schemas.js';
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
@@ -47,7 +47,7 @@ export const uploadFile = defineTool({
 
     if (response.status === 401 || response.status === 403) {
       clearAuthCache('microsoft-word');
-      throw ToolError.auth('Authentication expired — please refresh the page.');
+      authError('Authentication expired — please refresh the page.');
     }
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Ports the SharePoint/OneDrive hardening already shipped in the PowerPoint and Excel plugins to **Microsoft Word**. Works against SharePoint-hosted `.docx` files through the user's authenticated Microsoft Graph session via the existing pre-script token capture — no platform or SDK changes. The plugin goes from 27 → **28 tools**.

## What's new

**Auth recovery**
- `reauthenticate` clears MSAL local state and the captured-token mirror, then reloads the tab so MSAL re-acquires from the AAD token endpoint (silent via SSO) and the pre-script recaptures a fresh Graph token. On SharePoint/OneDrive documents the pre-script's captured token goes stale after ~1h once MSAL starts reading from its encrypted cache without re-hitting the token endpoint; this tool is the reliable recovery. (Mirrors the existing `excel-online` / `powerpoint` tools.)
- Every auth throw now routes through a shared `authError()` helper that appends `Call microsoft-word_reauthenticate to recover` on SharePoint documents, so a stale-token failure points at its own recovery path instead of a dead-end "please sign in" message.

**Editing robustness**
- The edit-in-place content PUTs (`update_document` / `append_to_document` / `replace_text_in_document` and `update_file_content`) map Graph's WOPI `423` (file open in the web editor) to a clear, actionable "close the editor tab and retry" error instead of a generic API error.
- `list_shared_with_me` bounds its result client-side because Graph ignores `$top` on `/me/drive/sharedWithMe` and returns the full set.

## Testing

- `tsc` + `opentabs-plugin build` clean — 28 tools bundled.
- Biome lint + format clean (34 files).
- Verified live on a stale SharePoint Word tab: `get_current_user` → `AUTH_ERROR` (no recovery path) → `reauthenticate` → retried `get_current_user` returns the profile. `list_shared_with_me top=3` returns exactly 3 items.

## Notes

- Scoped to `plugins/microsoft-word/src` only; no platform/extension/SDK changes.
- The `423` mapping is verified by code path but not exercised against a live WOPI lock (that would require a destructive write to an open document).
- Branches from `upstream/main`; single source-only commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Microsoft Word reauthentication tool to help recover access for SharePoint/OneDrive documents after auth issues.
* **Bug Fixes**
  * Improved Microsoft Graph “authentication expired” behavior with consistent messaging and retry guidance across Word actions.
  * Added clearer handling for locked Word web-editor documents (including guidance for HTTP 423).
  * Fixed “shared with me” listing to respect the selected limit and handle empty responses more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->