### PR TITLE
feat(outlook): match OWA compose — threaded drafts, signature, and default font

### DIFF
--- a/plugins/outlook/src/compose-defaults.ts
+++ b/plugins/outlook/src/compose-defaults.ts
@@ -1,0 +1,241 @@
+import { owsRequest } from './outlook-api.js';
+
+/**
+ * Applies the user's Outlook compose defaults — default font and signature — to
+ * bodies the plugin creates, so plugin-authored drafts match what OWA's compose
+ * surface produces. These are client-side OWA behaviors that Graph's mailboxSettings
+ * does not expose; they are read from OWS gateway endpoints on the OWA origin.
+ */
+
+/**
+ * OWA's default compose font family. There is no server-stored compose font *name* —
+ * startup data carries only size/color/flags — so the family is OWA's client default
+ * (the Aptos stack), matching what the compose surface renders.
+ */
+const DEFAULT_FONT_FAMILY = 'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, Calibri, Helvetica, sans-serif';
+const DEFAULT_FONT_SIZE_PT = 12;
+const DEFAULT_FONT_COLOR = '#000000';
+
+/** 3- or 6-digit hex color, so a server value can't break out of the style attribute. */
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?$/;
+
+/**
+ * OWA's rich-text compose font-size enum → point size — the classic Outlook/Word
+ * font-size scale (1–7). `3 ⇒ 12 pt` is confirmed against the live compose surface;
+ * values outside this range fall back to the 12 pt default.
+ */
+const FONT_SIZE_PT_BY_ENUM: Record<number, number> = {
+  1: 8,
+  2: 10,
+  3: 12,
+  4: 14,
+  5: 18,
+  6: 24,
+  7: 36,
+};
+
+/** OWA compose font style bit flags (Microsoft rich-text convention). */
+const FONT_FLAG_BOLD = 1;
+const FONT_FLAG_ITALIC = 2;
+const FONT_FLAG_UNDERLINE = 4;
+
+/** Which signature a body should carry. */
+export type SignatureKind = 'new' | 'reply' | 'none';
+
+interface ComposeDefaults {
+  fontFamily: string;
+  fontSizePt: number;
+  fontColor: string;
+  fontFlags: number;
+  /** Display name of the signature applied to new messages, or null if none set. */
+  newSignatureName: string | null;
+  /** Display name of the signature applied to replies/forwards, or null if none. */
+  replySignatureName: string | null;
+}
+
+/** One entry from an OWS settings response. */
+interface OwsSetting {
+  name?: string;
+  value?: string;
+  secondaryKey?: string;
+}
+
+/** Relevant slice of the OWA startup-data response. */
+interface StartupData {
+  owaUserConfig?: {
+    UserOptions?: {
+      ComposeFontSize?: number;
+      ComposeFontColor?: string;
+      ComposeFontFlags?: number;
+    };
+  };
+}
+
+// Compose defaults are stable for the page's lifetime, so cache them for the tab
+// session. A page reload (e.g. after the user edits a signature in OWA) refreshes.
+let cachedDefaults: ComposeDefaults | null = null;
+const signatureHtmlCache = new Map<string, string | null>();
+
+const escapeHtml = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+const textToHtml = (text: string): string => escapeHtml(text).replace(/\r\n|\r|\n/g, '<br>');
+
+/** Read the signature display-name defaults (new-mail + reply/forward) from OWS. */
+const readSignatureNames = async (): Promise<Pick<ComposeDefaults, 'newSignatureName' | 'replySignatureName'>> => {
+  const settings = await owsRequest<OwsSetting[]>('/ows/v1/OutlookCloudSettings/settings/', {
+    query: { settingname: 'roaming_signature_list,roaming_new_signature,roaming_reply_signature' },
+  });
+
+  // Field-name casing varies (roaming_new_signature vs Roaming_Reply_Signature), so
+  // key the lookup case-insensitively.
+  const byName = new Map<string, string>();
+  for (const setting of settings ?? []) {
+    if (setting.name && typeof setting.value === 'string') byName.set(setting.name.toLowerCase(), setting.value);
+  }
+
+  const nonEmpty = (value: string | undefined): string | null => (value && value.trim().length > 0 ? value : null);
+
+  return {
+    newSignatureName: nonEmpty(byName.get('roaming_new_signature')),
+    replySignatureName: nonEmpty(byName.get('roaming_reply_signature')),
+  };
+};
+
+type UserOptions = NonNullable<NonNullable<StartupData['owaUserConfig']>['UserOptions']>;
+
+/** Read the default compose font (size/color/flags) from OWA startup data. */
+const readFont = async (): Promise<Pick<ComposeDefaults, 'fontFamily' | 'fontSizePt' | 'fontColor' | 'fontFlags'>> => {
+  let options: UserOptions | undefined;
+  try {
+    const data = await owsRequest<StartupData>('/owa/startupdata.ashx', {
+      method: 'POST',
+      query: { app: 'Mail', n: 0 },
+      headers: { action: 'StartupData', 'x-owa-actionsource': 'StartupData', 'x-req-source': 'Mail' },
+    });
+    options = data?.owaUserConfig?.UserOptions;
+  } catch {
+    options = undefined;
+  }
+
+  const sizeEnum = options?.ComposeFontSize;
+  const fontSizePt = (typeof sizeEnum === 'number' && FONT_SIZE_PT_BY_ENUM[sizeEnum]) || DEFAULT_FONT_SIZE_PT;
+  const composeFontColor = options?.ComposeFontColor?.trim();
+  const fontColor =
+    composeFontColor && HEX_COLOR_PATTERN.test(composeFontColor) ? composeFontColor : DEFAULT_FONT_COLOR;
+  const fontFlags = typeof options?.ComposeFontFlags === 'number' ? options.ComposeFontFlags : 0;
+
+  return { fontFamily: DEFAULT_FONT_FAMILY, fontSizePt, fontColor, fontFlags };
+};
+
+/**
+ * Resolve (and cache) the user's compose defaults. The font lookup degrades to
+ * defaults on failure, but the signature-name lookup propagates whatever `owsRequest`
+ * throws (auth, rate-limit, non-OK, or network), so callers that must not fail — like
+ * `composeBody` — guard the call.
+ */
+const getComposeDefaults = async (): Promise<ComposeDefaults> => {
+  if (cachedDefaults) return cachedDefaults;
+  const [names, font] = await Promise.all([readSignatureNames(), readFont()]);
+  cachedDefaults = { ...font, ...names };
+  return cachedDefaults;
+};
+
+/**
+ * Fetch a signature's HTML body (with its logo inlined as a data-URI) by display
+ * name. Returns null when the signature has no HTML body. Requires the
+ * `x-islargesetting: true` header — signature bodies live in OWS's large-settings
+ * collection, and without it the gateway 404s.
+ */
+const getSignatureHtml = async (displayName: string): Promise<string | null> => {
+  const key = displayName.toLowerCase();
+  const cached = signatureHtmlCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const items = await owsRequest<OwsSetting[]>('/ows/v1/OutlookCloudSettings/settings/account', {
+    query: { settingname: displayName },
+    headers: { 'x-islargesetting': 'true' },
+  });
+
+  const html = items?.find(item => item.secondaryKey === 'htm')?.value;
+  const result = typeof html === 'string' && html.length > 0 ? html : null;
+  signatureHtmlCache.set(key, result);
+  return result;
+};
+
+/** Wrap body HTML in the default-font div OWA applies to the compose surface. */
+const wrapInDefaultFont = (html: string, defaults: ComposeDefaults): string => {
+  const styles = [
+    `font-family: ${defaults.fontFamily}`,
+    `font-size: ${defaults.fontSizePt}pt`,
+    `color: ${defaults.fontColor}`,
+  ];
+  if (defaults.fontFlags & FONT_FLAG_BOLD) styles.push('font-weight: bold');
+  if (defaults.fontFlags & FONT_FLAG_ITALIC) styles.push('font-style: italic');
+  if (defaults.fontFlags & FONT_FLAG_UNDERLINE) styles.push('text-decoration: underline');
+  return `<div style="${styles.join('; ')}">${html}</div>`;
+};
+
+/** An HTML email body ready to send to the Graph/Outlook draft APIs. */
+export interface ComposedBody {
+  contentType: 'HTML';
+  content: string;
+}
+
+/**
+ * Compose an HTML email body with the user's default compose font and (optionally)
+ * their Outlook signature applied — matching what OWA's compose surface produces.
+ * Plain-text input is escaped and wrapped in the default-font div; HTML input is
+ * kept as-is (assumed already styled by the caller). The signature, with its inline
+ * data-URI images, is appended below the body. Degrades gracefully: if compose
+ * defaults or the signature can't be fetched, the body is still returned as safe
+ * HTML — a draft is never blocked on fetching a signature.
+ */
+export const composeBody = async (input: {
+  body: string;
+  bodyType: 'text' | 'html';
+  signature: SignatureKind;
+}): Promise<ComposedBody> => {
+  const bodyHtml = input.bodyType === 'html' ? input.body : textToHtml(input.body);
+
+  let defaults: ComposeDefaults | null = null;
+  try {
+    defaults = await getComposeDefaults();
+  } catch {
+    defaults = null;
+  }
+
+  // Only synthesize the default font for plain-text input; HTML input is trusted to
+  // carry its own styling.
+  const styledBody = defaults && input.bodyType === 'text' ? wrapInDefaultFont(bodyHtml, defaults) : bodyHtml;
+
+  let signatureHtml: string | null = null;
+  if (defaults && input.signature !== 'none') {
+    const name = input.signature === 'new' ? defaults.newSignatureName : defaults.replySignatureName;
+    if (name) {
+      try {
+        signatureHtml = await getSignatureHtml(name);
+      } catch {
+        signatureHtml = null;
+      }
+    }
+  }
+
+  const content = signatureHtml ? `${styledBody}<br>${signatureHtml}` : styledBody;
+  return { contentType: 'HTML', content };
+};
+
+/**
+ * Convenience wrapper over `composeBody` for the message tools: maps a tool's
+ * `body_type` / `include_signature` inputs to compose options, applying the given
+ * signature kind unless the caller opted out with `include_signature: false`.
+ */
+export const composeToolBody = (
+  input: { body: string; body_type?: 'text' | 'html'; include_signature?: boolean },
+  signatureKind: Exclude<SignatureKind, 'none'>,
+): Promise<ComposedBody> =>
+  composeBody({
+    body: input.body,
+    bodyType: input.body_type === 'html' ? 'html' : 'text',
+    signature: input.include_signature === false ? 'none' : signatureKind,
+  });

--- a/plugins/outlook/src/outlook-api.ts
+++ b/plugins/outlook/src/outlook-api.ts
@@ -399,3 +399,179 @@ export const api = async <T>(
 
   throw ToolError.auth('Authentication expired — please refresh the Outlook page.');
 };
+
+// OWS gateway lives on the OWA page's own origin — a third base distinct from Graph
+// and Outlook REST. It serves the client-side compose settings (roaming signatures,
+// startup data) that Graph's mailboxSettings does not expose. The adapter runs on
+// whichever OWA host matched (outlook.cloud.microsoft, outlook.office.com, or
+// outlook.office365.com), so resolve against the current origin to stay same-origin
+// rather than hardcoding one host. Read lazily (not at module scope) because the
+// plugin module is also loaded in Node at build time, where `window` is undefined.
+const owsBaseUrl = (): string => window.location.origin;
+const OWS_AUTH_CACHE_KEY = 'outlook-ows';
+
+/** MSAL access-token claims OWS routing headers are derived from. */
+interface OwsTokenClaims {
+  puid?: string;
+  tid?: string;
+}
+
+/**
+ * Read the `puid`/`tid` claims from an MSAL access token's JWT payload. No signature
+ * verification — the token is already trusted (we minted the request with it); we
+ * only need its routing hints. Returns an empty object for any malformed token.
+ */
+const decodeTokenClaims = (jwt: string): OwsTokenClaims => {
+  const payload = jwt.split('.')[1];
+  if (!payload) return {};
+  try {
+    const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    return {
+      puid: typeof parsed.puid === 'string' ? parsed.puid : undefined,
+      tid: typeof parsed.tid === 'string' ? parsed.tid : undefined,
+    };
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Build the header set OWS gateway endpoints expect. The mailbox anchor
+ * (`x-anchormailbox` / `x-routingparameter-sessionkey`) is derived from the token's
+ * own `puid`/`tid` claims so the gateway routes to the right mailbox's settings.
+ */
+const buildOwsHeaders = (token: string, extra?: Record<string, string>): Record<string, string> => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/json',
+    'x-ms-appname': 'owa-reactmail',
+    owaappid: '00000002-0000-0ff1-ce00-000000000000',
+    'x-outlook-client': 'owa',
+    ...extra,
+  };
+  const { puid, tid } = decodeTokenClaims(token);
+  if (puid) {
+    const anchor = tid ? `PUID:${puid}@${tid}` : `PUID:${puid}`;
+    headers['x-anchormailbox'] = anchor;
+    headers['x-routingparameter-sessionkey'] = anchor;
+  }
+  return headers;
+};
+
+/**
+ * Encode an OWS query string with `encodeURIComponent` per value, yielding `%20` for
+ * spaces (in signature display names) and `%2C` for commas (the `settingname` list
+ * delimiter) — both of which the OWS gateway accepts. `URLSearchParams` is avoided
+ * because it encodes spaces as `+`, which OWS does not decode back to a space.
+ */
+const encodeOwsQuery = (query: Record<string, string | number | boolean | undefined>): string => {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined) continue;
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  }
+  return parts.join('&');
+};
+
+interface OwsRequestOptions {
+  method?: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  headers?: Record<string, string>;
+}
+
+type OwsOutcome<T> = { kind: 'ok'; data: T } | { kind: 'notFound' } | { kind: 'authFail' };
+
+/**
+ * Send one OWS request with a specific token. OWS is same-origin, so cookies ride
+ * along with the Bearer token. A 404 means the token authenticated but the settings
+ * collection holds no such item (e.g. a signature with no body) — distinct from
+ * 401/403, which signals "try the next candidate token".
+ */
+const sendOwsRequest = async <T>(
+  token: string,
+  endpoint: string,
+  options: OwsRequestOptions,
+): Promise<OwsOutcome<T>> => {
+  const qs = options.query ? encodeOwsQuery(options.query) : '';
+  const base = owsBaseUrl();
+  const url = qs ? `${base}${endpoint}?${qs}` : `${base}${endpoint}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: options.method ?? 'GET',
+      headers: buildOwsHeaders(token, options.headers),
+      credentials: 'same-origin',
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'TimeoutError') {
+      throw ToolError.timeout('Microsoft settings request timed out.');
+    }
+    throw new ToolError(`Network error: ${err instanceof Error ? err.message : 'unknown'}`, 'network_error', {
+      category: 'internal',
+      retryable: true,
+    });
+  }
+
+  if (response.status === 401 || response.status === 403) return { kind: 'authFail' };
+  if (response.status === 404) return { kind: 'notFound' };
+  if (response.status === 429) {
+    const retryAfter = response.headers.get('Retry-After');
+    const retryMs = retryAfter ? Number.parseInt(retryAfter, 10) * 1000 : undefined;
+    throw ToolError.rateLimited('Microsoft API rate limit exceeded.', retryMs);
+  }
+  if (!response.ok) {
+    throw ToolError.internal(`Microsoft settings request failed (${response.status}).`);
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const data = contentType.includes('application/json') ? ((await response.json()) as T) : ({} as T);
+  return { kind: 'ok', data };
+};
+
+/**
+ * Request an OWS gateway endpoint on the OWA origin (roaming signature settings,
+ * startup data), cascading through every MSAL candidate on 401/403 exactly like
+ * `api()` and caching the winner in its own slot. Returns `undefined` when a token
+ * authenticated but the endpoint returned 404 (no such setting), so callers can
+ * treat a missing signature as "none configured" rather than an error. Throws only
+ * when no candidate authenticates at all.
+ */
+export const owsRequest = async <T>(endpoint: string, options: OwsRequestOptions = {}): Promise<T | undefined> => {
+  const cached = getAuthCache<OutlookAuth>(OWS_AUTH_CACHE_KEY);
+  if (cached) {
+    const outcome = await sendOwsRequest<T>(cached.token, endpoint, options);
+    if (outcome.kind === 'ok') return outcome.data;
+    if (outcome.kind === 'notFound') return undefined;
+    clearAuthCache(OWS_AUTH_CACHE_KEY);
+  }
+
+  const candidates = collectAuthCandidates();
+  const remaining = cached ? candidates.filter(c => c.token !== cached.token) : candidates;
+  if (remaining.length === 0) {
+    throw ToolError.auth(
+      cached
+        ? 'Authentication expired — please refresh the Outlook page.'
+        : 'Not authenticated — please sign in to Microsoft 365.',
+    );
+  }
+
+  for (const auth of remaining) {
+    const outcome = await sendOwsRequest<T>(auth.token, endpoint, options);
+    if (outcome.kind === 'ok') {
+      setAuthCache(OWS_AUTH_CACHE_KEY, auth);
+      return outcome.data;
+    }
+    // A 404 means this token authenticated (the gateway resolved its mailbox) and the
+    // setting is simply absent — a valid winner to cache, so a genuinely-missing
+    // signature does not re-cascade through every token on each subsequent call.
+    if (outcome.kind === 'notFound') {
+      setAuthCache(OWS_AUTH_CACHE_KEY, auth);
+      return undefined;
+    }
+  }
+
+  throw ToolError.auth('Authentication expired — please refresh the Outlook page.');
+};

--- a/plugins/outlook/src/tools/create-draft.ts
+++ b/plugins/outlook/src/tools/create-draft.ts
@@ -1,12 +1,13 @@
 import { defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
 export const createDraft = defineTool({
   name: 'create_draft',
   displayName: 'Create Draft',
   description:
-    'Create a draft email message in the Drafts folder. The user can review and send it manually from Outlook.',
+    "Create a draft for a brand-new, standalone email in the Drafts folder. The user's default compose font and signature are applied automatically — do not write a signature into the body yourself. The user can review and send it manually from Outlook. This does NOT thread onto an existing conversation — to draft a reply that quotes the original thread, use reply_to_message with draft set to true; to draft a forward, use forward_message with draft set to true.",
   summary: 'Create a draft email',
   icon: 'file-edit',
   group: 'Messages',
@@ -18,6 +19,10 @@ export const createDraft = defineTool({
     cc: z.array(z.string()).optional().describe('CC recipient email addresses'),
     bcc: z.array(z.string()).optional().describe('BCC recipient email addresses'),
     importance: z.enum(['low', 'normal', 'high']).optional().describe('Importance level'),
+    include_signature: z
+      .boolean()
+      .optional()
+      .describe("Append the user's Outlook signature to the draft (default: true)"),
   }),
   output: z.object({
     draft_id: z.string().describe('The created draft message ID'),
@@ -26,13 +31,15 @@ export const createDraft = defineTool({
   handle: async params => {
     const toRecipients = (addrs: string[]) => addrs.map(addr => ({ emailAddress: { address: addr } }));
 
+    const body = await composeToolBody(params, 'new');
+
     const data = await api<{ id: string; webLink?: string }>('/me/messages', {
       method: 'POST',
       body: {
         subject: params.subject,
         body: {
-          contentType: params.body_type === 'html' ? 'HTML' : 'Text',
-          content: params.body,
+          contentType: body.contentType,
+          content: body.content,
         },
         toRecipients: toRecipients(params.to),
         ccRecipients: params.cc ? toRecipients(params.cc) : undefined,

--- a/plugins/outlook/src/tools/forward-message.ts
+++ b/plugins/outlook/src/tools/forward-message.ts
@@ -1,11 +1,13 @@
-import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
 export const forwardMessage = defineTool({
   name: 'forward_message',
   displayName: 'Forward Message',
-  description: 'Forward an email message to one or more recipients with an optional comment.',
+  description:
+    "Forward an email message to one or more recipients with an optional comment. By default the forward is sent immediately. Set draft to true to instead save a draft to the Drafts folder for the user to review and send manually. Either way the original message is quoted, recipients are pre-filled, and the user's default compose font and signature are applied automatically to the comment — do not write a signature into the comment yourself.",
   summary: 'Forward an email',
   icon: 'forward',
   group: 'Messages',
@@ -13,18 +15,58 @@ export const forwardMessage = defineTool({
     message_id: z.string().describe('The message ID to forward'),
     to: z.array(z.string()).describe('Recipient email addresses'),
     comment: z.string().optional().describe('Optional comment to include above the forwarded message'),
+    draft: z.boolean().optional().describe('Save as a draft instead of sending immediately (default: false)'),
+    include_signature: z.boolean().optional().describe("Append the user's signature (default: true)"),
   }),
   output: z.object({
-    success: z.boolean().describe('Whether the message was forwarded'),
+    success: z.boolean().describe('Whether the operation completed'),
+    draft_id: z.string().optional().describe('Created draft message ID (only when draft is true)'),
+    web_link: z.string().optional().describe('Link to open the draft in Outlook (only when draft is true)'),
   }),
   handle: async params => {
-    await api(`/me/messages/${params.message_id}/forward`, {
-      method: 'POST',
-      body: {
-        comment: params.comment ?? '',
-        toRecipients: params.to.map(addr => ({ emailAddress: { address: addr } })),
-      },
-    });
+    const toRecipients = params.to.map(addr => ({ emailAddress: { address: addr } }));
+
+    // createForward produces a draft with the original message quoted and recipients
+    // pre-filled. The comment — styled with the default font and signature — is layered
+    // on top of the returned quoted body with a follow-up PATCH (passing a comment to
+    // the create action inserts unstyled text). For an immediate forward the same
+    // composed draft is then sent, keeping font/signature identical to the draft path.
+    const draft = await api<{ id?: string; webLink?: string; body?: { content?: string } }>(
+      `/me/messages/${params.message_id}/createForward`,
+      { method: 'POST', body: { toRecipients } },
+    );
+    const draftId = draft.id;
+    if (!draftId) throw ToolError.internal('Forward draft was created without a message id.');
+
+    const quoted = draft.body?.content ?? '';
+    const applyBody = async () => {
+      const composed = await composeToolBody(
+        { body: params.comment ?? '', include_signature: params.include_signature },
+        'reply',
+      );
+      await api(`/me/messages/${draftId}`, {
+        method: 'PATCH',
+        body: { body: { contentType: 'HTML', content: `${composed.content}${quoted}` } },
+      });
+    };
+
+    // Compose the comment onto the created draft. Any failure here means nothing was
+    // sent, so delete the draft rather than leave an orphan — for both draft mode and
+    // immediate send.
+    try {
+      await applyBody();
+    } catch (err) {
+      await api(`/me/messages/${draftId}`, { method: 'DELETE' }).catch(() => {});
+      throw err;
+    }
+
+    if (params.draft) {
+      return { success: true, draft_id: draftId, web_link: draft.webLink ?? '' };
+    }
+
+    // A failure of the send itself is ambiguous (the message may already be on its
+    // way), so the draft is left in place rather than risk deleting a sent message.
+    await api(`/me/messages/${draftId}/send`, { method: 'POST' });
     return { success: true };
   },
 });

--- a/plugins/outlook/src/tools/reply-to-message.ts
+++ b/plugins/outlook/src/tools/reply-to-message.ts
@@ -1,36 +1,74 @@
-import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
 export const replyToMessage = defineTool({
   name: 'reply_to_message',
   displayName: 'Reply to Message',
-  description: 'Reply to an email message. Set reply_all to true to reply to all recipients.',
+  description:
+    "Reply to an email message. By default the reply is sent immediately. Set draft to true to instead save a threaded draft to the Drafts folder for the user to review and send manually. Either way the original conversation is quoted, reply headers are set, and the user's default compose font and reply signature are applied automatically — do not write a signature into the body yourself. Set reply_all to true to reply to all recipients.",
   summary: 'Reply to an email',
   icon: 'reply',
   group: 'Messages',
   input: z.object({
     message_id: z.string().describe('The message ID to reply to'),
     body: z.string().describe('Reply body content'),
-    body_type: z.enum(['text', 'html']).optional().describe('Body content type (default: text)'),
+    body_type: z
+      .enum(['text', 'html'])
+      .optional()
+      .describe('Body content type (default: text). HTML is inserted as-is above the quoted thread.'),
     reply_all: z.boolean().optional().describe('Reply to all recipients (default: false)'),
+    draft: z.boolean().optional().describe('Save as a threaded draft instead of sending immediately (default: false)'),
+    include_signature: z.boolean().optional().describe("Append the user's reply signature (default: true)"),
   }),
   output: z.object({
-    success: z.boolean().describe('Whether the reply was sent'),
+    success: z.boolean().describe('Whether the operation completed'),
+    draft_id: z.string().optional().describe('Created draft message ID (only when draft is true)'),
+    web_link: z.string().optional().describe('Link to open the draft in Outlook (only when draft is true)'),
   }),
   handle: async params => {
-    const action = params.reply_all ? 'replyAll' : 'reply';
-    await api(`/me/messages/${params.message_id}/${action}`, {
-      method: 'POST',
-      body:
-        params.body_type === 'html'
-          ? {
-              message: {
-                body: { contentType: 'HTML', content: params.body },
-              },
-            }
-          : { comment: params.body },
-    });
+    // createReply/createReplyAll have the server build a draft with the original
+    // conversation quoted, recipients pre-filled, and reply headers set. The action
+    // takes no body, so the user's text — styled with the default font and reply
+    // signature — is layered on top of the returned quoted history with a follow-up
+    // PATCH (passing a body to the create action would replace the quote and lose the
+    // thread). For an immediate reply the same composed draft is then sent; this keeps
+    // the font/signature identical whether replying live or saving a draft.
+    const draftAction = params.reply_all ? 'createReplyAll' : 'createReply';
+    const draft = await api<{ id?: string; webLink?: string; body?: { content?: string } }>(
+      `/me/messages/${params.message_id}/${draftAction}`,
+      { method: 'POST' },
+    );
+    const draftId = draft.id;
+    if (!draftId) throw ToolError.internal('Reply draft was created without a message id.');
+
+    const quoted = draft.body?.content ?? '';
+    const applyBody = async () => {
+      const composed = await composeToolBody(params, 'reply');
+      await api(`/me/messages/${draftId}`, {
+        method: 'PATCH',
+        body: { body: { contentType: 'HTML', content: `${composed.content}${quoted}` } },
+      });
+    };
+
+    // Compose the reply onto the created draft. Any failure here means nothing was
+    // sent, so delete the draft rather than leave an orphan — for both draft mode and
+    // immediate send.
+    try {
+      await applyBody();
+    } catch (err) {
+      await api(`/me/messages/${draftId}`, { method: 'DELETE' }).catch(() => {});
+      throw err;
+    }
+
+    if (params.draft) {
+      return { success: true, draft_id: draftId, web_link: draft.webLink ?? '' };
+    }
+
+    // A failure of the send itself is ambiguous (the message may already be on its
+    // way), so the draft is left in place rather than risk deleting a sent message.
+    await api(`/me/messages/${draftId}/send`, { method: 'POST' });
     return { success: true };
   },
 });

--- a/plugins/outlook/src/tools/send-message.ts
+++ b/plugins/outlook/src/tools/send-message.ts
@@ -1,11 +1,13 @@
 import { defineTool } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
 export const sendMessage = defineTool({
   name: 'send_message',
   displayName: 'Send Message',
-  description: 'Send a new email message. Supports plain text or HTML body, CC/BCC, and importance level.',
+  description:
+    "Send a new email message. The user's default compose font and signature are applied automatically — do not write a signature into the body yourself. Supports plain text or HTML body, CC/BCC, and importance level.",
   summary: 'Send an email',
   icon: 'send',
   group: 'Messages',
@@ -18,6 +20,7 @@ export const sendMessage = defineTool({
     bcc: z.array(z.string()).optional().describe('BCC recipient email addresses'),
     importance: z.enum(['low', 'normal', 'high']).optional().describe('Importance level (default: normal)'),
     save_to_sent: z.boolean().optional().describe('Save to Sent Items folder (default: true)'),
+    include_signature: z.boolean().optional().describe("Append the user's signature (default: true)"),
   }),
   output: z.object({
     success: z.boolean().describe('Whether the message was sent'),
@@ -25,14 +28,16 @@ export const sendMessage = defineTool({
   handle: async params => {
     const toRecipients = (addrs: string[]) => addrs.map(addr => ({ emailAddress: { address: addr } }));
 
+    const body = await composeToolBody(params, 'new');
+
     await api('/me/sendMail', {
       method: 'POST',
       body: {
         message: {
           subject: params.subject,
           body: {
-            contentType: params.body_type === 'html' ? 'HTML' : 'Text',
-            content: params.body,
+            contentType: body.contentType,
+            content: body.content,
           },
           toRecipients: toRecipients(params.to),
           ccRecipients: params.cc ? toRecipients(params.cc) : undefined,


### PR DESCRIPTION
## What

Brings plugin-composed Outlook mail in line with what OWA's compose surface produces:

1. **Threaded reply/forward drafts** — `reply_to_message` / `forward_message` gain a `draft` mode that saves a threaded draft (quoted conversation, reply headers, recipients pre-filled) to Drafts for manual review.
2. **Automatic signature** — the user's Outlook signature (with its inline logo) is applied to drafts and sends.
3. **Default compose font** — plain-text bodies are wrapped in the user's default compose font (family/size/color), matching OWA.

## Why

Signatures and the default compose font are client-side OWA *compose* behaviors — Microsoft Graph's `mailboxSettings` exposes neither. The plugin's tools go straight to the API, so nothing signed or styled the body and agents had to fabricate signatures. This reads the real values from the first-party OWS gateway and applies them deterministically.

## How

- **`owsRequest()` transport** (`outlook-api.ts`): a same-origin fetch to the OWS gateway on `outlook.cloud.microsoft`, reusing the existing MSAL token cascade in its own cache slot, with the mailbox anchor derived from each token's `puid`/`tid` claims. Signature bodies live in the OWS *large-settings* collection and require the `x-islargesetting` header.
- **`compose-defaults.ts`**: resolves signature names + default font (session-cached), fetches a signature's HTML (logo inlined as a `data:` URI — self-contained, no image hosting), and composes an HTML body. **Degrades gracefully** — if settings can't be fetched, a valid plain body is still returned; a draft is never blocked.
- Wired into `create_draft`, `send_message`, `reply_to_message`, `forward_message` for both draft and immediate send. Reply/forward run both modes through `createReply`/`createForward` → PATCH → send, so font, signature, and the quoted thread are identical either way.

## Behavior changes (called out explicitly)

- `create_draft` and `send_message` now send text bodies as `contentType: HTML` so the default font can be applied — escaped text renders identically.
- Immediate reply/forward are reimplemented as `createReply`/`createForward` → PATCH → send (previously single `/reply` / `/forward` actions). A composing failure cleans up the created draft; a send failure leaves the draft in place (ambiguous — the message may already be on its way, so it is not deleted).
- New `include_signature` input (default `true`) on the four tools.

## Testing

Verified live against enterprise M365 mailbox: `create_draft`, `send_message`, and both immediate and draft reply/forward produce the default-font wrapper plus the correct signature (new-mail vs reply), with the quoted thread preserved on reply/forward. The design is account-neutral (cross-tenant token cascade; anchor derived from each token's own claims; OWA-standard setting names). Not yet verified against personal outlook.com accounts, or mailboxes whose signatures live only in the legacy single-signature store — both fall back to no signature rather than erroring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Outlook email composition for drafts, replies, forwards, and sends now preserves Outlook compose formatting and automatically applies the default compose font and signature.
  * Added an option to omit the signature.
  * Replies and forwards can be saved as drafts; when enabled, draft links are returned and user text is composed above quoted thread content.

* **Bug Fixes**
  * Improved plain-text handling by escaping special characters and preserving line breaks, with graceful fallback when compose defaults or signature data can’t be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->