### PR TITLE
feat(outlook): file attachments for compose tools (embedded + OneDrive link)

### DIFF
--- a/plugins/outlook/src/attachments.ts
+++ b/plugins/outlook/src/attachments.ts
@@ -1,0 +1,114 @@
+import { ToolError } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import {
+  attachFileToMessage,
+  attachLargeFileToMessage,
+  attachReferenceToMessage,
+  uploadAttachmentToOneDrive,
+} from './outlook-api.js';
+
+/**
+ * Adds attachments to draft messages the plugin creates. A file's bytes arrive as a
+ * base64 string in the tool params — the plugin runs in the browser page context and
+ * has no filesystem access, so a path on disk is not reachable. Each attachment is
+ * either embedded as a copy of its bytes (a `fileAttachment`) or, when
+ * `as_cloud_link` is set, uploaded to the user's OneDrive and attached as a sharing
+ * link (a `referenceAttachment`).
+ */
+
+/**
+ * Largest file embedded inline as base64 `contentBytes`. Microsoft rejects a single
+ * attachment request over ~3 MB, so anything larger needs a chunked upload session.
+ */
+const INLINE_ATTACHMENT_LIMIT_BYTES = 3_000_000;
+
+/** Shared input shape for one attachment, reused across every compose tool. */
+export const attachmentInputSchema = z.object({
+  name: z.string().min(1).describe('File name including extension, e.g. "report.pdf"'),
+  content_base64: z
+    .string()
+    .min(1)
+    .describe(
+      'File content, base64-encoded. A data: URI prefix (e.g. "data:application/pdf;base64,") is accepted and stripped.',
+    ),
+  content_type: z.string().optional().describe('MIME type (default: application/octet-stream)'),
+  as_cloud_link: z
+    .boolean()
+    .optional()
+    .describe(
+      'Attach as a OneDrive sharing link instead of embedding a copy of the file (default: false). Use for large files or documents recipients should open in the cloud.',
+    ),
+});
+
+export type AttachmentInput = z.infer<typeof attachmentInputSchema>;
+
+/** Strip an optional `data:` URI prefix, returning the bare base64 payload. */
+const stripDataUri = (value: string): string => {
+  if (!value.startsWith('data:')) return value;
+  const comma = value.indexOf(',');
+  return comma === -1 ? value : value.slice(comma + 1);
+};
+
+/** Decode a base64 string to its raw bytes. */
+const decodeBase64 = (base64: string): Uint8Array<ArrayBuffer> => {
+  const binary = atob(base64);
+  const buffer = new ArrayBuffer(binary.length);
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
+/** Decoded byte length of a base64 string, computed without allocating the bytes. */
+const base64ByteLength = (base64: string): number => {
+  if (base64.length === 0) return 0;
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+};
+
+/** Attach one file to a draft, dispatching on embed-vs-link and size. */
+const attachOne = async (messageId: string, input: AttachmentInput): Promise<void> => {
+  const contentBase64 = stripDataUri(input.content_base64.trim());
+  if (contentBase64.length === 0) throw ToolError.validation(`Attachment "${input.name}" has no content.`);
+
+  // A cloud link uploads the bytes to OneDrive and references the file by sharing link,
+  // so it is not bound by the inline-embed size ceiling.
+  if (input.as_cloud_link) {
+    const bytes = decodeBase64(contentBase64);
+    const sourceUrl = await uploadAttachmentToOneDrive(
+      input.name,
+      bytes,
+      input.content_type ?? 'application/octet-stream',
+    );
+    await attachReferenceToMessage(messageId, { name: input.name, sourceUrl });
+    return;
+  }
+
+  // A single inline request cannot carry more than ~3 MB of base64, so larger embeds
+  // stream the raw bytes to the draft through a chunked upload session instead.
+  if (base64ByteLength(contentBase64) > INLINE_ATTACHMENT_LIMIT_BYTES) {
+    await attachLargeFileToMessage(messageId, {
+      name: input.name,
+      contentType: input.content_type,
+      bytes: decodeBase64(contentBase64),
+    });
+    return;
+  }
+
+  await attachFileToMessage(messageId, {
+    name: input.name,
+    contentType: input.content_type,
+    contentBase64,
+  });
+};
+
+/**
+ * Attach files to a draft message in order. Attachments are applied sequentially —
+ * concurrent POSTs to the same message race on its change key — so a failure stops
+ * the run and propagates, leaving the draft with whatever attached before it.
+ */
+export const attachToDraft = async (messageId: string, attachments: AttachmentInput[] | undefined): Promise<void> => {
+  if (!attachments || attachments.length === 0) return;
+  for (const attachment of attachments) {
+    await attachOne(messageId, attachment);
+  }
+};

--- a/plugins/outlook/src/index.ts
+++ b/plugins/outlook/src/index.ts
@@ -1,6 +1,7 @@
 import { OpenTabsPlugin } from '@opentabs-dev/plugin-sdk';
 import type { ToolDefinition } from '@opentabs-dev/plugin-sdk';
 import { isAuthenticated, waitForAuth } from './outlook-api.js';
+import { addAttachment } from './tools/add-attachment.js';
 import { createDraft } from './tools/create-draft.js';
 import { createEvent } from './tools/create-event.js';
 import { deleteEvent } from './tools/delete-event.js';
@@ -55,6 +56,7 @@ class OutlookPlugin extends OpenTabsPlugin {
     listAttachments,
     getAttachmentContent,
     downloadAttachment,
+    addAttachment,
     // Folders
     listFolders,
     // Calendar

--- a/plugins/outlook/src/outlook-api.ts
+++ b/plugins/outlook/src/outlook-api.ts
@@ -350,6 +350,52 @@ const sendRequest = async <T>(
   return (isOutlookApi ? normalizeKeys(json) : json) as T;
 };
 
+/** The outcome of one cascade attempt: `done` stops and caches the token; otherwise advance. */
+type CascadeAttempt<R> = { done: true; value: R } | { done: false };
+
+/**
+ * Try `attempt` with each auth candidate for a capability's cache slot: the cached
+ * winner first, then every other MSAL candidate, caching whichever token the attempt
+ * accepts. `attempt` returns `{ done: true, value }` to stop (caching that token), or
+ * `{ done: false }` to advance to the next candidate (as on a 401/403). Throws an auth
+ * error when no candidate is accepted. This is the shared spine of every authenticated
+ * transport (`api`, `owsRequest`, `attachFileToMessage`) — each differs only in how it
+ * maps a response to a done/advance outcome.
+ */
+const cascadeAuth = async <R>(
+  cacheKey: string,
+  attempt: (auth: OutlookAuth) => Promise<CascadeAttempt<R>>,
+): Promise<R> => {
+  const cached = getAuthCache<OutlookAuth>(cacheKey);
+  if (cached) {
+    const outcome = await attempt(cached);
+    // The cached token is already stored — return without re-caching it.
+    if (outcome.done) return outcome.value;
+    clearAuthCache(cacheKey);
+  }
+
+  const candidates = collectAuthCandidates();
+  // Skip the cached candidate we just tried — it 401'd, no point retrying it.
+  const remaining = cached ? candidates.filter(c => c.token !== cached.token) : candidates;
+  if (remaining.length === 0) {
+    throw ToolError.auth(
+      cached
+        ? 'Authentication expired — please refresh the Outlook page.'
+        : 'Not authenticated — please sign in to Microsoft 365.',
+    );
+  }
+
+  for (const auth of remaining) {
+    const outcome = await attempt(auth);
+    if (outcome.done) {
+      setAuthCache(cacheKey, auth);
+      return outcome.value;
+    }
+  }
+
+  throw ToolError.auth('Authentication expired — please refresh the Outlook page.');
+};
+
 /**
  * Make an authenticated request to a Microsoft 365 API for the given capability,
  * cascading through every MSAL-cached candidate on 401/403 (the capability's cached
@@ -368,37 +414,11 @@ export const api = async <T>(
     headers?: Record<string, string>;
   } = {},
   capability: Capability = 'mail',
-): Promise<T> => {
-  const cacheKey = AUTH_CACHE_KEY[capability];
-
-  const cached = getAuthCache<OutlookAuth>(cacheKey);
-  if (cached) {
-    const r = await sendRequest<T>(cached, endpoint, options);
-    if (r !== null) return r;
-    clearAuthCache(cacheKey);
-  }
-
-  const candidates = collectAuthCandidates();
-  // Skip the cached candidate we just tried — it 401'd, no point retrying it.
-  const remaining = cached ? candidates.filter(c => c.token !== cached.token) : candidates;
-  if (remaining.length === 0) {
-    throw ToolError.auth(
-      cached
-        ? 'Authentication expired — please refresh the Outlook page.'
-        : 'Not authenticated — please sign in to Microsoft 365.',
-    );
-  }
-
-  for (const auth of remaining) {
+): Promise<T> =>
+  cascadeAuth<T>(AUTH_CACHE_KEY[capability], async auth => {
     const r = await sendRequest<T>(auth, endpoint, options);
-    if (r !== null) {
-      setAuthCache(cacheKey, auth);
-      return r;
-    }
-  }
-
-  throw ToolError.auth('Authentication expired — please refresh the Outlook page.');
-};
+    return r === null ? { done: false } : { done: true, value: r };
+  });
 
 // OWS gateway lives on the OWA page's own origin — a third base distinct from Graph
 // and Outlook REST. It serves the client-side compose settings (roaming signatures,
@@ -539,39 +559,243 @@ const sendOwsRequest = async <T>(
  * treat a missing signature as "none configured" rather than an error. Throws only
  * when no candidate authenticates at all.
  */
-export const owsRequest = async <T>(endpoint: string, options: OwsRequestOptions = {}): Promise<T | undefined> => {
-  const cached = getAuthCache<OutlookAuth>(OWS_AUTH_CACHE_KEY);
-  if (cached) {
-    const outcome = await sendOwsRequest<T>(cached.token, endpoint, options);
-    if (outcome.kind === 'ok') return outcome.data;
-    if (outcome.kind === 'notFound') return undefined;
-    clearAuthCache(OWS_AUTH_CACHE_KEY);
-  }
-
-  const candidates = collectAuthCandidates();
-  const remaining = cached ? candidates.filter(c => c.token !== cached.token) : candidates;
-  if (remaining.length === 0) {
-    throw ToolError.auth(
-      cached
-        ? 'Authentication expired — please refresh the Outlook page.'
-        : 'Not authenticated — please sign in to Microsoft 365.',
-    );
-  }
-
-  for (const auth of remaining) {
+export const owsRequest = async <T>(endpoint: string, options: OwsRequestOptions = {}): Promise<T | undefined> =>
+  cascadeAuth<T | undefined>(OWS_AUTH_CACHE_KEY, async auth => {
     const outcome = await sendOwsRequest<T>(auth.token, endpoint, options);
-    if (outcome.kind === 'ok') {
-      setAuthCache(OWS_AUTH_CACHE_KEY, auth);
-      return outcome.data;
-    }
+    if (outcome.kind === 'ok') return { done: true, value: outcome.data };
     // A 404 means this token authenticated (the gateway resolved its mailbox) and the
     // setting is simply absent — a valid winner to cache, so a genuinely-missing
     // signature does not re-cascade through every token on each subsequent call.
-    if (outcome.kind === 'notFound') {
-      setAuthCache(OWS_AUTH_CACHE_KEY, auth);
-      return undefined;
+    if (outcome.kind === 'notFound') return { done: true, value: undefined };
+    return { done: false };
+  });
+
+/** Graph vs Outlook REST namespaces for the fileAttachment OData type. */
+const FILE_ATTACHMENT_ODATA_TYPE: Record<'graph' | 'outlook', string> = {
+  graph: '#microsoft.graph.fileAttachment',
+  outlook: '#Microsoft.OutlookServices.FileAttachment',
+};
+
+/** A file to embed in a message as a copy of its bytes. */
+export interface FileAttachmentInput {
+  /** File name including extension, e.g. "report.pdf". */
+  name: string;
+  /** MIME type; defaults to application/octet-stream. */
+  contentType?: string;
+  /** Base64-encoded file content, with no data: URI prefix. */
+  contentBase64: string;
+}
+
+/**
+ * Embed a file in an existing draft as a `fileAttachment`. Reuses the `mail` cache
+ * slot so the attach lands on the same token — and therefore the same API base and
+ * message-id namespace — that created the draft (a draft id minted on Graph is not
+ * valid on Outlook REST, and vice versa). The attachment body is built per base: the
+ * two APIs disagree on the OData type namespace, and `sendRequest` PascalCases the
+ * property keys for the Outlook REST base while leaving Graph's camelCase untouched.
+ */
+export const attachFileToMessage = async (messageId: string, attachment: FileAttachmentInput): Promise<void> =>
+  cascadeAuth<void>(AUTH_CACHE_KEY.mail, async auth => {
+    const namespace = auth.apiBase === GRAPH_API_BASE ? 'graph' : 'outlook';
+    const body = {
+      '@odata.type': FILE_ATTACHMENT_ODATA_TYPE[namespace],
+      name: attachment.name,
+      contentType: attachment.contentType ?? 'application/octet-stream',
+      contentBytes: attachment.contentBase64,
+    };
+    const r = await sendRequest<unknown>(auth, `/me/messages/${messageId}/attachments`, { method: 'POST', body });
+    return r === null ? { done: false } : { done: true, value: undefined };
+  });
+
+/**
+ * Graph vs Outlook REST namespaces and enum casing for the referenceAttachment OData
+ * type. Graph spells the enums camelCase; Outlook REST spells them PascalCase. Only
+ * the property keys are transformed by `sendRequest` — the string enum *values* are
+ * set here per base.
+ */
+const REFERENCE_ATTACHMENT: Record<'graph' | 'outlook', { type: string; providerType: string; permission: string }> = {
+  graph: { type: '#microsoft.graph.referenceAttachment', providerType: 'oneDriveBusiness', permission: 'view' },
+  outlook: {
+    type: '#Microsoft.OutlookServices.ReferenceAttachment',
+    providerType: 'OneDriveBusiness',
+    permission: 'View',
+  },
+};
+
+/** A file already in OneDrive, attached to a message as a sharing link. */
+export interface ReferenceAttachmentInput {
+  /** File name including extension, e.g. "report.pdf". */
+  name: string;
+  /** The OneDrive sharing-link URL recipients open the file from. */
+  sourceUrl: string;
+}
+
+/**
+ * Attach a OneDrive file to a draft as a `referenceAttachment` (a sharing link rather
+ * than an embedded copy). Reuses the `mail` cache slot for the same base/message-id
+ * reasons as {@link attachFileToMessage}, and builds the body per base.
+ */
+export const attachReferenceToMessage = async (
+  messageId: string,
+  attachment: ReferenceAttachmentInput,
+): Promise<void> =>
+  cascadeAuth<void>(AUTH_CACHE_KEY.mail, async auth => {
+    const meta = REFERENCE_ATTACHMENT[auth.apiBase === GRAPH_API_BASE ? 'graph' : 'outlook'];
+    const body = {
+      '@odata.type': meta.type,
+      name: attachment.name,
+      sourceUrl: attachment.sourceUrl,
+      providerType: meta.providerType,
+      permission: meta.permission,
+      isFolder: false,
+    };
+    const r = await sendRequest<unknown>(auth, `/me/messages/${messageId}/attachments`, { method: 'POST', body });
+    return r === null ? { done: false } : { done: true, value: undefined };
+  });
+
+/** Wrap a fetch rejection as a structured, retryable network error. */
+const toNetworkError = (err: unknown): ToolError => {
+  if (err instanceof DOMException && err.name === 'TimeoutError') {
+    return ToolError.timeout('Microsoft API request timed out.');
+  }
+  return new ToolError(`Network error: ${err instanceof Error ? err.message : 'unknown'}`, 'network_error', {
+    category: 'internal',
+    retryable: true,
+  });
+};
+
+/**
+ * Cloud attachments need Drive write scope, which mail tokens do not carry, so they
+ * cascade in their own cache slot restricted to Graph tokens — the only base that can
+ * reach `/me/drive`. A mail-scoped Graph token 401/403s and the cascade advances; if
+ * no candidate carries Files scope, the caller sees a clean auth error.
+ */
+const FILES_AUTH_CACHE_KEY = 'outlook-files';
+
+/** The OneDrive folder cloud attachments are uploaded to, mirroring OWA's compose. */
+const ONEDRIVE_ATTACHMENTS_FOLDER = 'Attachments';
+
+/**
+ * Upload a file to the user's OneDrive and return an organization-scoped view link for
+ * it — the source URL a `referenceAttachment` points at. Uploading and link creation
+ * share one Graph Files-scoped token, discovered by cascading only through Graph
+ * candidates (a Drive call is meaningless against the Outlook REST base). A single PUT
+ * to `/content` handles files up to Graph's simple-upload ceiling (250 MB), so cloud
+ * attachments carry the large files embedding cannot.
+ */
+export const uploadAttachmentToOneDrive = async (
+  name: string,
+  bytes: Uint8Array<ArrayBuffer>,
+  contentType: string,
+): Promise<string> =>
+  cascadeAuth<string>(FILES_AUTH_CACHE_KEY, async auth => {
+    if (auth.apiBase !== GRAPH_API_BASE) return { done: false };
+    const authHeader = { Authorization: `Bearer ${auth.token}` };
+    const encodedPath = `${encodeURIComponent(ONEDRIVE_ATTACHMENTS_FOLDER)}/${encodeURIComponent(name)}`;
+
+    let uploadRes: Response;
+    try {
+      uploadRes = await fetch(`${GRAPH_API_BASE}/me/drive/root:/${encodedPath}:/content`, {
+        method: 'PUT',
+        headers: { ...authHeader, 'Content-Type': contentType },
+        body: new Blob([bytes]),
+        credentials: 'omit',
+        signal: AbortSignal.timeout(120_000),
+      });
+    } catch (err) {
+      throw toNetworkError(err);
+    }
+    if (uploadRes.status === 401 || uploadRes.status === 403) return { done: false };
+    if (!uploadRes.ok) throw ToolError.internal(`OneDrive upload failed (${uploadRes.status}).`);
+    const item = (await uploadRes.json()) as { id?: string };
+    if (!item.id) throw ToolError.internal('OneDrive upload returned no item id.');
+
+    let linkRes: Response;
+    try {
+      linkRes = await fetch(`${GRAPH_API_BASE}/me/drive/items/${item.id}/createLink`, {
+        method: 'POST',
+        headers: { ...authHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'view', scope: 'organization' }),
+        credentials: 'omit',
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch (err) {
+      throw toNetworkError(err);
+    }
+    if (linkRes.status === 401 || linkRes.status === 403) return { done: false };
+    if (!linkRes.ok) throw ToolError.internal(`OneDrive share-link creation failed (${linkRes.status}).`);
+    const link = (await linkRes.json()) as { link?: { webUrl?: string } };
+    const webUrl = link.link?.webUrl;
+    if (!webUrl) throw ToolError.internal('OneDrive share-link response contained no URL.');
+    return { done: true, value: webUrl };
+  });
+
+/**
+ * Upload-session chunk size. Microsoft requires every chunk but the last to be a
+ * multiple of 320 KiB; this is 10 × 320 KiB (3.125 MiB), comfortably under the 4 MiB
+ * per-request ceiling.
+ */
+const UPLOAD_SESSION_CHUNK_BYTES = 320 * 1024 * 10;
+
+/** A file whose bytes are streamed to a draft, for embeds too large to inline. */
+export interface LargeFileAttachmentInput {
+  /** File name including extension, e.g. "report.pdf". */
+  name: string;
+  /** MIME type; defaults to application/octet-stream. */
+  contentType?: string;
+  /** Raw file bytes. */
+  bytes: Uint8Array<ArrayBuffer>;
+}
+
+/**
+ * Embed a file too large for a single inline request (over ~3 MB) by opening a Graph
+ * attachment upload session and streaming the bytes to it in sequential chunks. The
+ * session is opened on the draft's mail token/base — the same base/message-id
+ * reasoning as {@link attachFileToMessage} — while the returned `uploadUrl` is
+ * pre-authorized, so the chunk PUTs carry no bearer token. The final chunk's response
+ * commits the attachment.
+ */
+export const attachLargeFileToMessage = async (messageId: string, file: LargeFileAttachmentInput): Promise<void> => {
+  const contentType = file.contentType ?? 'application/octet-stream';
+  const total = file.bytes.byteLength;
+
+  const session = await cascadeAuth<{ uploadUrl?: string }>(AUTH_CACHE_KEY.mail, async auth => {
+    // createUploadSession exists only on Graph (Outlook REST v2.0 is decommissioned),
+    // so skip any Outlook REST candidate rather than let it throw and abort the cascade.
+    if (auth.apiBase !== GRAPH_API_BASE) return { done: false };
+    const body = { AttachmentItem: { attachmentType: 'file', name: file.name, size: total, contentType } };
+    const r = await sendRequest<{ uploadUrl?: string }>(
+      auth,
+      `/me/messages/${messageId}/attachments/createUploadSession`,
+      { method: 'POST', body },
+    );
+    return r === null ? { done: false } : { done: true, value: r };
+  });
+
+  const uploadUrl = session.uploadUrl;
+  if (!uploadUrl) throw ToolError.internal('Attachment upload session returned no upload URL.');
+
+  // The uploadUrl is pre-authorized; chunks must be sent in order. Content-Length is a
+  // forbidden header the browser sets itself, so only Content-Range is set here.
+  for (let start = 0; start < total; start += UPLOAD_SESSION_CHUNK_BYTES) {
+    const end = Math.min(start + UPLOAD_SESSION_CHUNK_BYTES, total);
+    const chunk = file.bytes.subarray(start, end);
+
+    let res: Response;
+    try {
+      res = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Range': `bytes ${start}-${end - 1}/${total}` },
+        body: new Blob([chunk]),
+        credentials: 'omit',
+        signal: AbortSignal.timeout(120_000),
+      });
+    } catch (err) {
+      throw toNetworkError(err);
+    }
+    // 200 accepts an intermediate chunk; 201 commits the attachment on the final chunk.
+    if (res.status !== 200 && res.status !== 201) {
+      throw ToolError.internal(`Attachment chunk upload failed (${res.status}).`);
     }
   }
-
-  throw ToolError.auth('Authentication expired — please refresh the Outlook page.');
 };

--- a/plugins/outlook/src/tools/add-attachment.ts
+++ b/plugins/outlook/src/tools/add-attachment.ts
@@ -1,0 +1,25 @@
+import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { z } from 'zod';
+import { attachToDraft, attachmentInputSchema } from '../attachments.js';
+
+export const addAttachment = defineTool({
+  name: 'add_attachment',
+  displayName: 'Add Attachment',
+  description:
+    'Attach one or more files to an existing draft message (created by create_draft, or a reply/forward saved with draft set to true). Files are provided as base64-encoded content. Attachments can only be added to drafts — not to already-sent messages.',
+  summary: 'Attach files to a draft',
+  icon: 'paperclip',
+  group: 'Messages',
+  input: z.object({
+    draft_id: z.string().min(1).describe('The draft message ID to attach the files to'),
+    attachments: z.array(attachmentInputSchema).min(1).describe('The files to attach'),
+  }),
+  output: z.object({
+    success: z.boolean().describe('Whether the files were attached'),
+    attached_count: z.number().describe('Number of files attached'),
+  }),
+  handle: async params => {
+    await attachToDraft(params.draft_id, params.attachments);
+    return { success: true, attached_count: params.attachments.length };
+  },
+});

--- a/plugins/outlook/src/tools/create-draft.ts
+++ b/plugins/outlook/src/tools/create-draft.ts
@@ -1,5 +1,6 @@
-import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { attachToDraft, attachmentInputSchema } from '../attachments.js';
 import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
@@ -23,6 +24,7 @@ export const createDraft = defineTool({
       .boolean()
       .optional()
       .describe("Append the user's Outlook signature to the draft (default: true)"),
+    attachments: z.array(attachmentInputSchema).optional().describe('Files to attach to the draft'),
   }),
   output: z.object({
     draft_id: z.string().describe('The created draft message ID'),
@@ -47,6 +49,20 @@ export const createDraft = defineTool({
         importance: params.importance,
       },
     });
+
+    if (params.attachments?.length) {
+      const draftId = data.id;
+      if (!draftId) throw ToolError.internal('Draft was created without a message id.');
+      try {
+        await attachToDraft(draftId, params.attachments);
+      } catch (err) {
+        // Keep create_draft atomic: a partial attach failure deletes the draft rather
+        // than leave an orphan the caller never gets an id for.
+        await api(`/me/messages/${draftId}`, { method: 'DELETE' }).catch(() => {});
+        throw err;
+      }
+    }
+
     return {
       draft_id: data.id ?? '',
       web_link: data.webLink ?? '',

--- a/plugins/outlook/src/tools/forward-message.ts
+++ b/plugins/outlook/src/tools/forward-message.ts
@@ -1,5 +1,6 @@
 import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { attachToDraft, attachmentInputSchema } from '../attachments.js';
 import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
@@ -17,6 +18,7 @@ export const forwardMessage = defineTool({
     comment: z.string().optional().describe('Optional comment to include above the forwarded message'),
     draft: z.boolean().optional().describe('Save as a draft instead of sending immediately (default: false)'),
     include_signature: z.boolean().optional().describe("Append the user's signature (default: true)"),
+    attachments: z.array(attachmentInputSchema).optional().describe('Additional files to attach to the forward'),
   }),
   output: z.object({
     success: z.boolean().describe('Whether the operation completed'),
@@ -48,6 +50,7 @@ export const forwardMessage = defineTool({
         method: 'PATCH',
         body: { body: { contentType: 'HTML', content: `${composed.content}${quoted}` } },
       });
+      await attachToDraft(draftId, params.attachments);
     };
 
     // Compose the comment onto the created draft. Any failure here means nothing was

--- a/plugins/outlook/src/tools/reply-to-message.ts
+++ b/plugins/outlook/src/tools/reply-to-message.ts
@@ -1,5 +1,6 @@
 import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { attachToDraft, attachmentInputSchema } from '../attachments.js';
 import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
@@ -21,6 +22,7 @@ export const replyToMessage = defineTool({
     reply_all: z.boolean().optional().describe('Reply to all recipients (default: false)'),
     draft: z.boolean().optional().describe('Save as a threaded draft instead of sending immediately (default: false)'),
     include_signature: z.boolean().optional().describe("Append the user's reply signature (default: true)"),
+    attachments: z.array(attachmentInputSchema).optional().describe('Files to attach to the reply'),
   }),
   output: z.object({
     success: z.boolean().describe('Whether the operation completed'),
@@ -50,6 +52,7 @@ export const replyToMessage = defineTool({
         method: 'PATCH',
         body: { body: { contentType: 'HTML', content: `${composed.content}${quoted}` } },
       });
+      await attachToDraft(draftId, params.attachments);
     };
 
     // Compose the reply onto the created draft. Any failure here means nothing was

--- a/plugins/outlook/src/tools/send-message.ts
+++ b/plugins/outlook/src/tools/send-message.ts
@@ -1,5 +1,6 @@
-import { defineTool } from '@opentabs-dev/plugin-sdk';
+import { defineTool, ToolError } from '@opentabs-dev/plugin-sdk';
 import { z } from 'zod';
+import { attachToDraft, attachmentInputSchema } from '../attachments.js';
 import { composeToolBody } from '../compose-defaults.js';
 import { api } from '../outlook-api.js';
 
@@ -7,7 +8,7 @@ export const sendMessage = defineTool({
   name: 'send_message',
   displayName: 'Send Message',
   description:
-    "Send a new email message. The user's default compose font and signature are applied automatically — do not write a signature into the body yourself. Supports plain text or HTML body, CC/BCC, and importance level.",
+    "Send a new email message. The user's default compose font and signature are applied automatically — do not write a signature into the body yourself. Supports plain text or HTML body, CC/BCC, importance level, and file attachments. Note: when attachments are included the message is always filed in Sent Items (save_to_sent does not apply).",
   summary: 'Send an email',
   icon: 'send',
   group: 'Messages',
@@ -19,8 +20,14 @@ export const sendMessage = defineTool({
     cc: z.array(z.string()).optional().describe('CC recipient email addresses'),
     bcc: z.array(z.string()).optional().describe('BCC recipient email addresses'),
     importance: z.enum(['low', 'normal', 'high']).optional().describe('Importance level (default: normal)'),
-    save_to_sent: z.boolean().optional().describe('Save to Sent Items folder (default: true)'),
+    save_to_sent: z
+      .boolean()
+      .optional()
+      .describe(
+        'Save to Sent Items folder (default: true). Ignored when attachments are present — those are always saved.',
+      ),
     include_signature: z.boolean().optional().describe("Append the user's signature (default: true)"),
+    attachments: z.array(attachmentInputSchema).optional().describe('Files to attach to the message'),
   }),
   output: z.object({
     success: z.boolean().describe('Whether the message was sent'),
@@ -29,21 +36,42 @@ export const sendMessage = defineTool({
     const toRecipients = (addrs: string[]) => addrs.map(addr => ({ emailAddress: { address: addr } }));
 
     const body = await composeToolBody(params, 'new');
+    const message = {
+      subject: params.subject,
+      body: {
+        contentType: body.contentType,
+        content: body.content,
+      },
+      toRecipients: toRecipients(params.to),
+      ccRecipients: params.cc ? toRecipients(params.cc) : undefined,
+      bccRecipients: params.bcc ? toRecipients(params.bcc) : undefined,
+      importance: params.importance,
+    };
+
+    // sendMail takes a message payload with no server-side id, so there is nothing to
+    // attach files to. When attachments are present, create a draft, attach the files,
+    // then send it — which always files the sent copy in Sent Items.
+    if (params.attachments && params.attachments.length > 0) {
+      const draft = await api<{ id?: string }>('/me/messages', { method: 'POST', body: message });
+      const draftId = draft.id;
+      if (!draftId) throw ToolError.internal('Draft was created without a message id.');
+
+      try {
+        await attachToDraft(draftId, params.attachments);
+      } catch (err) {
+        // Nothing was sent, so delete the partially-built draft rather than orphan it.
+        await api(`/me/messages/${draftId}`, { method: 'DELETE' }).catch(() => {});
+        throw err;
+      }
+
+      await api(`/me/messages/${draftId}/send`, { method: 'POST' });
+      return { success: true };
+    }
 
     await api('/me/sendMail', {
       method: 'POST',
       body: {
-        message: {
-          subject: params.subject,
-          body: {
-            contentType: body.contentType,
-            content: body.content,
-          },
-          toRecipients: toRecipients(params.to),
-          ccRecipients: params.cc ? toRecipients(params.cc) : undefined,
-          bccRecipients: params.bcc ? toRecipients(params.bcc) : undefined,
-          importance: params.importance,
-        },
+        message,
         saveToSentItems: params.save_to_sent ?? true,
       },
     });


### PR DESCRIPTION
## What

Adds outgoing file attachments to the Outlook plugin's compose tools. Each attachment is either **embedded** as a copy of its bytes (`fileAttachment`) or, with `as_cloud_link`, uploaded to the user's OneDrive and attached as an organization-scoped sharing link (`referenceAttachment`).

Available on `create_draft`, `send_message`, `reply_to_message`, and `forward_message` via an `attachments[]` param, plus a standalone **`add_attachment`** tool for existing drafts.

| Type | Mechanism | Size |
| --- | --- | --- |
| Embedded, small | single inline `POST .../attachments` | ≤ 3 MB |
| Embedded, large | chunked Graph upload session | > 3 MB |
| Cloud link | OneDrive `PUT` + `createLink` → `referenceAttachment` | ≤ 250 MB |

## Design notes

- **Base64 input.** The plugin runs in the browser page with no filesystem, so a file's bytes arrive as a base64 string in the tool params (a `data:` prefix is stripped) — the same convention as the existing `microsoft-word_upload_file` / `wrike_upload_attachment` tools.
- **Attach on the draft's API base.** A message id minted on Graph is not valid on Outlook REST and vice versa, so attachments reuse the cached `mail` token that created the draft, and the attachment body is built per base (`#microsoft.graph.fileAttachment` vs `#Microsoft.OutlookServices.FileAttachment`; enum casing likewise).
- **Cloud uploads use a separate cache slot.** Drive writes need `Files` scope, which mail tokens lack, so `uploadAttachmentToOneDrive` cascades in its own slot restricted to Graph candidates.
- **`send_message` with attachments** switches from `sendMail` (which has no message id to attach to) to create-draft → attach → send; documented that the sent copy is always filed in Sent Items in that case.
- Refactors the auth-cascade boilerplate that `api()` and `owsRequest()` each hand-rolled into a single `cascadeAuth()` helper the new transports reuse.

## Testing

Verified live against a real enterprise mailbox and cleaned up afterward:

- `create_draft` + embedded file, and the standalone `add_attachment` (incl. `data:` prefix) — both land as `fileAttachment`.
- `create_draft` + `as_cloud_link` — OWA renders the cloud-link attachment (verified in the draft body).
- `reply_to_message` (draft) + embedded — attachment coexists with the reply signature and quoted thread.
- Chunked upload session — exercised end to end (`createUploadSession` → `Content-Range` chunk PUT → commit) by temporarily lowering the inline threshold so a small file routed through it; lands as an embedded `fileAttachment`.

Plugin `build` + `type-check` + `lint` + `format` all pass.

Builds on the compose-parity work in #137 (threaded drafts, signature, default font).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outlook drafts, replies, forwards, and sent messages now support file attachments.
  * Attachments can be added inline or uploaded as cloud links for larger files.
  * Attachment support is now available as a standalone action for existing drafts.

* **Bug Fixes**
  * Improved handling of large attachments and upload errors.
  * Drafts are cleaned up automatically if attachment processing fails, helping avoid incomplete messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->