### PR TITLE
fix: hide transient console window on Windows version checks

### DIFF
--- a/platform/mcp-server/src/version-check.ts
+++ b/platform/mcp-server/src/version-check.ts
@@ -35,6 +35,9 @@ export const fetchLatestVersion = async (packageName: string): Promise<string | 
     const child = spawn('npm', ['view', packageName, 'version'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows(),
+      // On Windows, shell: true launches cmd.exe, which flashes a console
+      // window when the parent has none. Hide it — this runs on a timer.
+      windowsHide: true,
     });
 
     const stdoutChunks: Buffer[] = [];


### PR DESCRIPTION
## Problem

When the OpenTabs MCP server runs in the background on Windows, a console window flashes on screen periodically — roughly on the version-check interval.

## Cause

The periodic plugin/server version check in `version-check.ts` spawns `npm view` with `shell: true` on Windows (npm is a `.cmd` wrapper and can't be spawned without a shell). `spawn`'s `windowsHide` option defaults to `false`, so the `cmd.exe` that runs the check pops a visible console window each interval when the parent process has no console of its own.

## Fix

Pass `windowsHide: true` to the `spawn` call so the shell runs hidden.

```ts
const child = spawn('npm', ['view', packageName, 'version'], {
  stdio: ['ignore', 'pipe', 'pipe'],
  shell: isWindows(),
  windowsHide: true,
});
```

Only the interval-driven check is affected here; the one-shot user-triggered spawns (plugin install/update) don't cause a recurring flash, so they're left as-is.

## Verification

- `npx tsc --build` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a transient console window from appearing on Windows during update checks when no parent console is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->