### PR TITLE
fix(extension): probe every side panel API the toggle branch uses

### DIFF
--- a/platform/browser-extension/src/side-panel-toggle.ts
+++ b/platform/browser-extension/src/side-panel-toggle.ts
@@ -47,9 +47,11 @@ export const initSidePanelToggle = (): void => {
   chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
 
   // Chrome 141+ — track open/close state per window for toggle behavior.
-  // On older Chrome (114–140), these APIs are undefined; openWindows stays
-  // empty and the action click always opens the side panel.
-  const canToggle = 'onOpened' in chrome.sidePanel;
+  // Every member the toggle branch relies on is probed individually: Chrome 150
+  // ships onOpened without onClosed, so checking only onOpened throws at the
+  // top level and kills service worker registration. When any member is
+  // missing, openWindows stays empty and the action click always opens.
+  const canToggle = 'onOpened' in chrome.sidePanel && 'onClosed' in chrome.sidePanel && 'close' in chrome.sidePanel;
 
   if (canToggle) {
     // Restore persisted open-window state so the toggle works correctly after


### PR DESCRIPTION
Fixes #145

## Problem

On Chrome 150 the extension service worker never registers:

```
Service worker registration failed. Status code: 15
Uncaught TypeError: Cannot read properties of undefined (reading 'addListener')
    at dist/background.js:63 (anonymous function)
```

`initSidePanelToggle()` guards the toggle branch on `'onOpened' in chrome.sidePanel`, but the branch itself touches three members: `onOpened`, `onClosed`, and `close()`. Chrome 150 ships `onOpened` without `onClosed`, so the guard passes, `chrome.sidePanel.onClosed.addListener(...)` throws at the top level, and registration dies.

The failure mode is quiet: the server side is healthy (`opentabs doctor` reports `WebSocket handshake: authenticated`), `opentabs status` just sits at `Extension  not connected`, and the server log shows no connection attempts at all because the worker never runs to retry.

## Change

One-line guard widening — probe every member the branch uses instead of just one:

```ts
const canToggle = 'onOpened' in chrome.sidePanel && 'onClosed' in chrome.sidePanel && 'close' in chrome.sidePanel;
```

When any member is missing, `canToggle` is false and behavior falls back to open-only — the exact path Chrome 114–140 already takes. No behavior change on Chrome versions that expose the full API.

The surrounding comment is updated to say why each member is probed separately, so the assumption "these ship together from 141" does not get reintroduced.

## Verification

Applied the equivalent patch to the built `dist/background.js` of an installed `0.0.114` on the affected machine (Chrome 150.0.7871.184, macOS 15, Node v22.16.0) and reloaded the extension:

```
15:04:39 Extension WebSocket connected [A]
```

```
opentabs status
  Extension       connected
  Browser tools   76
```

Before the patch: no connection attempt was ever logged. `npx @biomejs/biome check` passes on the changed file. There are no existing tests for `platform/browser-extension`, so none were added.
